### PR TITLE
Multiple code improvements - squid:S1192, squid:S1118, squid:S1213, squid:CommentedOutCodeLine, squid:S1185, squid:S2275, squid:S3398

### DIFF
--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/BladeProcessor.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/BladeProcessor.java
@@ -57,7 +57,6 @@ public class BladeProcessor extends BaseProcessor {
                 Class<ProcessorModule> moduleClass = (Class<ProcessorModule>) Class.forName(moduleClassName.toString());
                 ProcessorModule module = moduleClass.newInstance();
                 mModules.add(module);
-                //System.out.println("> APT using " + moduleClass.getSimpleName());
             } catch (Exception ignore) {
                 // module is not accessible
             }

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/BaseClassBuilder.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/BaseClassBuilder.java
@@ -172,7 +172,6 @@ public abstract class BaseClassBuilder
         // create file
         JavaFile javaFile = JavaFile.builder(getClassName().packageName(), cls).build();
         javaFile.writeTo(processingEnvironment.getFiler());
-        //javaFile.writeTo(System.out);
 
         if (LOG_SUCCESS) {
             System.out.println(String.format("Class <%s> successfully generated.", getFullName()));

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/ClassManager.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/ClassManager.java
@@ -25,7 +25,15 @@ import eu.f3rog.blade.compiler.util.ProcessorError;
 public class ClassManager
         implements IBuildable {
 
+    private final Map<Class, BaseClassBuilder> mSpecialClasses;
+    private final Map<ClassName, HelperClassBuilder> mHelpers;
+
     private static ClassManager sInstance;
+
+    private ClassManager() {
+        mSpecialClasses = new HashMap<>();
+        mHelpers = new HashMap<>();
+    }
 
     public static void init() {
         sInstance = new ClassManager();
@@ -33,14 +41,6 @@ public class ClassManager
 
     public static ClassManager getInstance() {
         return sInstance;
-    }
-
-    private final Map<Class, BaseClassBuilder> mSpecialClasses;
-    private final Map<ClassName, HelperClassBuilder> mHelpers;
-
-    private ClassManager() {
-        mSpecialClasses = new HashMap<>();
-        mHelpers = new HashMap<>();
     }
 
     public HelperClassBuilder getHelper(TypeElement e) throws ProcessorError {

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/annotation/GeneratedForBuilder.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/annotation/GeneratedForBuilder.java
@@ -13,6 +13,8 @@ import eu.f3rog.blade.core.GeneratedFor;
  */
 public class GeneratedForBuilder {
 
+    private GeneratedForBuilder() {}
+
     public static AnnotationSpec buildFor(Class cls) {
         return AnnotationSpec.builder(GeneratedFor.class)
                 .addMember("value", "$T.class", cls)

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/annotation/WeaveBuilder.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/annotation/WeaveBuilder.java
@@ -124,19 +124,19 @@ public final class WeaveBuilder {
             }
             return array;
         }
-    }
 
-    private static String formatFor(String f, final int count) {
-        StringBuilder format = new StringBuilder();
-        format.append("{");
-        for (int i = 0; i < count; i++) {
-            if (i > 0) {
-                format.append(", ");
+        private static String formatFor(String f, final int count) {
+            StringBuilder format = new StringBuilder();
+            format.append("{");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) {
+                    format.append(", ");
+                }
+                format.append(f);
             }
-            format.append(f);
+            format.append("}");
+            return format.toString();
         }
-        format.append("}");
-        return format.toString();
     }
 
 }

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/module/BundleUtils.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/module/BundleUtils.java
@@ -12,6 +12,8 @@ import java.util.List;
  */
 public class BundleUtils {
 
+    private BundleUtils() {}
+
     public static void getFromBundle(MethodSpec.Builder method,
                                      String targetName,
                                      List<String> fields,

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/name/GN.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/name/GN.java
@@ -10,6 +10,8 @@ import com.squareup.javapoet.ClassName;
  */
 public class GN {
 
+    private GN() {}
+
     public static ClassName className(GCN genClassName, String arg, GPN... packages) {
         return ClassName.get(GPN.toString(packages), genClassName.formatName(arg));
     }

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/util/ProcessorUtils.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/util/ProcessorUtils.java
@@ -52,7 +52,6 @@ public class ProcessorUtils {
     }
 
     public static String fullName(ClassName className) {
-        //return String.format("%s.%s", className.packageName(), className.simpleName());
         StringBuilder sb = new StringBuilder();
 
         sb.append(className.packageName());

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/util/StringUtils.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/util/StringUtils.java
@@ -8,6 +8,8 @@ package eu.f3rog.blade.compiler.util;
  */
 public class StringUtils {
 
+    private StringUtils() {}
+
     public static String startLowerCase(final String className) {
         return className.substring(0, 1).toLowerCase()
                 + className.substring(1);

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/arg/ArgTest.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/arg/ArgTest.java
@@ -26,9 +26,13 @@ import static eu.f3rog.blade.compiler.util.File.generatedFile;
  */
 public final class ArgTest extends BaseTest {
 
+    public static final String MAIN_FRAGMENT = "MainFragment";
+    public static final String COM_EXAMPLE = "com.example";
+    public static final String PUBLIC_CLASS_T_EXTENDS_FRAGMENT = "public class $T extends Fragment {";
+
     @Test
     public void invalidCLass() {
-        JavaFileObject input = file("com.example", "MainFragment")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_FRAGMENT)
                 .imports(
                         Arg.class, "A"
                 )
@@ -48,13 +52,13 @@ public final class ArgTest extends BaseTest {
 
     @Test
     public void invalidField() {
-        JavaFileObject input = file("com.example", "MainFragment")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_FRAGMENT)
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
                         "   @$A private String mExtraString;",
                         "",
@@ -66,13 +70,13 @@ public final class ArgTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, Arg.class.getSimpleName()));
 
-        input = file("com.example", "MainFragment")
+        input = file(COM_EXAMPLE, MAIN_FRAGMENT)
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
                         "   @$A protected String mExtraString;",
                         "",
@@ -84,13 +88,13 @@ public final class ArgTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, Arg.class.getSimpleName()));
 
-        input = file("com.example", "MainFragment")
+        input = file(COM_EXAMPLE, MAIN_FRAGMENT)
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
                         "   @$A final String mExtraString;",
                         "",
@@ -105,13 +109,13 @@ public final class ArgTest extends BaseTest {
 
     @Test
     public void one() {
-        JavaFileObject input = file("com.example", "MainFragment")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_FRAGMENT)
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
                         "   @$A String mExtraString;",
                         "   @$A int mA;",
@@ -119,7 +123,7 @@ public final class ArgTest extends BaseTest {
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MainFragment_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MainFragment_Helper")
                 .imports(
                         input, "I",
                         BundleWrapper.class,
@@ -150,7 +154,7 @@ public final class ArgTest extends BaseTest {
 
     @Test
     public void none() {
-        JavaFileObject input = file("com.example", "MainFragment")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_FRAGMENT)
                 .imports(
                         Blade.class, "B",
                         Fragment.class

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/arg/FragmentFactoryTest.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/arg/FragmentFactoryTest.java
@@ -23,9 +23,21 @@ import static eu.f3rog.blade.compiler.util.File.generatedFile;
  */
 public final class FragmentFactoryTest extends BaseTest {
 
+    public static final String COM_EXAMPLE = "com.example";
+    public static final String BW_ARGS_NEW_BW = "       $BW args = new $BW();";
+    public static final String BLADE = "blade";
+    public static final String PUBLIC_CLASS_T = "public class $T {";
+    public static final String FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE = "       fragment.setArguments(args.getBundle());";
+    public static final String RETURN_FRAGMENT = "       return fragment;";
+    public static final String PUBLIC_CLASS_T_EXTENDS_FRAGMENT = "public class $T extends Fragment {";
+    public static final String A_INT_NUMBER = "   @$A int number;";
+    public static final String ARGS_PUT_ARG_NUMBER_NUMBER = "       args.put(\"<Arg-number>\", number);";
+    public static final String ARGS_PUT_ARG_TEXT_TEXT = "       args.put(\"<Arg-text>\", text);";
+    public static final String A_STRING_TEXT = "   @$A String text;";
+
     @Test
     public void none() {
-        JavaFileObject input = file("com.example", "SomeFragment")
+        JavaFileObject input = file(COM_EXAMPLE, "SomeFragment")
                 .imports(
                         Fragment.class,
                         Blade.class, "B"
@@ -35,19 +47,19 @@ public final class FragmentFactoryTest extends BaseTest {
                         "public class $T extends Fragment {}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "F")
+        JavaFileObject expected = generatedFile(BLADE, "F")
                 .imports(
                         input, "I",
                         BundleWrapper.class, "BW"
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   public static $I new$I() {",
                         "       $I fragment = new $I();",
-                        "       $BW args = new $BW();",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        BW_ARGS_NEW_BW,
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "}"
@@ -62,34 +74,34 @@ public final class FragmentFactoryTest extends BaseTest {
 
     @Test
     public void one() {
-        JavaFileObject input = file("com.example", "SomeFragment")
+        JavaFileObject input = file(COM_EXAMPLE, "SomeFragment")
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
                         "   @$A String mText;",
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "F")
+        JavaFileObject expected = generatedFile(BLADE, "F")
                 .imports(
                         input, "I",
                         BundleWrapper.class, "BW",
                         String.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   public static $I new$I(String mText) {",
                         "       $I fragment = new $I();",
-                        "       $BW args = new $BW();",
+                        BW_ARGS_NEW_BW,
                         "       args.put(\"<Arg-mText>\", mText);",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "}"
@@ -104,34 +116,34 @@ public final class FragmentFactoryTest extends BaseTest {
 
     @Test
     public void more() {
-        JavaFileObject input1 = file("com.example", "FirstFragment")
+        JavaFileObject input1 = file(COM_EXAMPLE, "FirstFragment")
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
-                        "   @$A int number;",
+                        A_INT_NUMBER,
                         "",
                         "}"
                 );
-        JavaFileObject input2 = file("com.example", "SecondFragment")
+        JavaFileObject input2 = file(COM_EXAMPLE, "SecondFragment")
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
-                        "   @$A String text;",
+                        A_STRING_TEXT,
                         "   @$A boolean flag;",
                         "   @$A double number;",
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "F")
+        JavaFileObject expected = generatedFile(BLADE, "F")
                 .imports(
                         input1, "I1",
                         input2, "I2",
@@ -139,24 +151,24 @@ public final class FragmentFactoryTest extends BaseTest {
                         String.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   public static $I1 new$I1(int number) {",
                         "       $I1 fragment = new $I1();",
-                        "       $BW args = new $BW();",
-                        "       args.put(\"<Arg-number>\", number);",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        BW_ARGS_NEW_BW,
+                        ARGS_PUT_ARG_NUMBER_NUMBER,
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "   public static $I2 new$I2(String text, boolean flag, double number) {",
                         "       $I2 fragment = new $I2();",
-                        "       $BW args = new $BW();",
-                        "       args.put(\"<Arg-text>\", text);",
+                        BW_ARGS_NEW_BW,
+                        ARGS_PUT_ARG_TEXT_TEXT,
                         "       args.put(\"<Arg-flag>\", flag);",
-                        "       args.put(\"<Arg-number>\", number);",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        ARGS_PUT_ARG_NUMBER_NUMBER,
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "}"
@@ -171,19 +183,19 @@ public final class FragmentFactoryTest extends BaseTest {
 
     @Test
     public void inheritance() {
-        JavaFileObject base = file("com.example", "BaseFragment")
+        JavaFileObject base = file(COM_EXAMPLE, "BaseFragment")
                 .imports(
                         Arg.class, "A",
                         Fragment.class
                 )
                 .body(
-                        "public class $T extends Fragment {",
+                        PUBLIC_CLASS_T_EXTENDS_FRAGMENT,
                         "",
-                        "   @$A int number;",
+                        A_INT_NUMBER,
                         "",
                         "}"
                 );
-        JavaFileObject activity = file("com.example", "MyFragment")
+        JavaFileObject activity = file(COM_EXAMPLE, "MyFragment")
                 .imports(
                         Arg.class, "A",
                         base, "B"
@@ -191,12 +203,12 @@ public final class FragmentFactoryTest extends BaseTest {
                 .body(
                         "public class $T extends $B {",
                         "",
-                        "   @$A String text;",
+                        A_STRING_TEXT,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "F")
+        JavaFileObject expected = generatedFile(BLADE, "F")
                 .imports(
                         base, "B",
                         activity, "A",
@@ -204,23 +216,23 @@ public final class FragmentFactoryTest extends BaseTest {
                         String.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   public static $B new$B(int number) {",
                         "       $B fragment = new $B();",
-                        "       $BW args = new $BW();",
-                        "       args.put(\"<Arg-number>\", number);",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        BW_ARGS_NEW_BW,
+                        ARGS_PUT_ARG_NUMBER_NUMBER,
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "   public static $A new$A(int number, String text) {",
                         "       $A fragment = new $A();",
-                        "       $BW args = new $BW();",
-                        "       args.put(\"<Arg-number>\", number);",
-                        "       args.put(\"<Arg-text>\", text);",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        BW_ARGS_NEW_BW,
+                        ARGS_PUT_ARG_NUMBER_NUMBER,
+                        ARGS_PUT_ARG_TEXT_TEXT,
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "}"
@@ -235,7 +247,7 @@ public final class FragmentFactoryTest extends BaseTest {
 
     @Test
     public void inheritanceFromAbstract() {
-        JavaFileObject base = file("com.example", "BaseFragment")
+        JavaFileObject base = file(COM_EXAMPLE, "BaseFragment")
                 .imports(
                         Arg.class, "A",
                         Fragment.class
@@ -243,11 +255,11 @@ public final class FragmentFactoryTest extends BaseTest {
                 .body(
                         "public abstract class $T extends Fragment {",
                         "",
-                        "   @$A int number;",
+                        A_INT_NUMBER,
                         "",
                         "}"
                 );
-        JavaFileObject activity = file("com.example", "MyFragment")
+        JavaFileObject activity = file(COM_EXAMPLE, "MyFragment")
                 .imports(
                         Arg.class, "A",
                         base, "B"
@@ -255,27 +267,27 @@ public final class FragmentFactoryTest extends BaseTest {
                 .body(
                         "public class $T extends $B {",
                         "",
-                        "   @$A String text;",
+                        A_STRING_TEXT,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "F")
+        JavaFileObject expected = generatedFile(BLADE, "F")
                 .imports(
                         activity, "A",
                         BundleWrapper.class, "BW",
                         String.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   public static $A new$A(int number, String text) {",
                         "       $A fragment = new $A();",
-                        "       $BW args = new $BW();",
-                        "       args.put(\"<Arg-number>\", number);",
-                        "       args.put(\"<Arg-text>\", text);",
-                        "       fragment.setArguments(args.getBundle());",
-                        "       return fragment;",
+                        BW_ARGS_NEW_BW,
+                        ARGS_PUT_ARG_NUMBER_NUMBER,
+                        ARGS_PUT_ARG_TEXT_TEXT,
+                        FRAGMENT_SET_ARGUMENTS_ARGS_GET_BUNDLE,
+                        RETURN_FRAGMENT,
                         "   }",
                         "",
                         "}"

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/extra/ExtraTest.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/extra/ExtraTest.java
@@ -30,16 +30,29 @@ import static eu.f3rog.blade.compiler.util.File.generatedFile;
  */
 public final class ExtraTest extends BaseTest {
 
+    public static final String MAIN_ACTIVITY = "MainActivity";
+    public static final String COM_EXAMPLE = "com.example";
+    public static final String E_STRING_M_EXTRA_STRING = "   @$E String mExtraString;";
+    public static final String PUBLIC_CLASS_T_EXTENDS_ACTIVITY = "public class $T extends Activity {";
+    public static final String E_INT_M_A = "   @$E int mA;";
+    public static final String ABSTRACT_CLASS_T = "abstract class $T {";
+    public static final String IF_INTENT_NULL_INTENT_GET_EXTRAS_NULL = "       if (intent == null || intent.getExtras() == null) {";
+    public static final String RETURN = "           return;";
+    public static final String BUNDLE_WRAPPER_EXTRAS_BUNDLE_WRAPPER_FROM_INTENT_GET_EXTRAS = "       BundleWrapper extras = BundleWrapper.from(intent.getExtras());";
+    public static final String TARGET_M_EXTRA_STRING_EXTRAS_GET_EXTRA_M_EXTRA_STRING_TARGET_M_EXTRA_STRING = "       target.mExtraString = extras.get(\"<Extra-mExtraString>\", target.mExtraString);";
+    public static final String TARGET_M_A_EXTRAS_GET_EXTRA_M_A_TARGET_M_A = "       target.mA = extras.get(\"<Extra-mA>\", target.mA);";
+    public static final String CLOSING_BRACE = "       }";
+
     @Test
     public void invalidCLass() {
-        JavaFileObject input = file("com.example", "MainActivity")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_ACTIVITY)
                 .imports(
                         Extra.class, "E"
                 )
                 .body(
                         "public class $T {",
                         "",
-                        "   @$E String mExtraString;",
+                        E_STRING_M_EXTRA_STRING,
                         "",
                         "}"
                 );
@@ -52,13 +65,13 @@ public final class ExtraTest extends BaseTest {
 
     @Test
     public void invalidField() {
-        JavaFileObject input = file("com.example", "MainActivity")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_ACTIVITY)
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
                         "   @$E private String mExtraString;",
                         "",
@@ -70,13 +83,13 @@ public final class ExtraTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, Extra.class.getSimpleName()));
 
-        input = file("com.example", "MainActivity")
+        input = file(COM_EXAMPLE, MAIN_ACTIVITY)
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
                         "   @$E protected String mExtraString;",
                         "",
@@ -88,13 +101,13 @@ public final class ExtraTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, Extra.class.getSimpleName()));
 
-        input = file("com.example", "MainActivity")
+        input = file(COM_EXAMPLE, MAIN_ACTIVITY)
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
                         "   @$E final String mExtraString;",
                         "",
@@ -109,7 +122,7 @@ public final class ExtraTest extends BaseTest {
 
     @Test
     public void activityNone() {
-        JavaFileObject input = file("com.example", "MainActivity")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_ACTIVITY)
                 .imports(
                         Blade.class, "B",
                         Activity.class
@@ -128,21 +141,21 @@ public final class ExtraTest extends BaseTest {
 
     @Test
     public void activityOne() {
-        JavaFileObject input = file("com.example", "MainActivity")
+        JavaFileObject input = file(COM_EXAMPLE, MAIN_ACTIVITY)
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
-                        "   @$E String mExtraString;",
-                        "   @$E int mA;",
+                        E_STRING_M_EXTRA_STRING,
+                        E_INT_M_A,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MainActivity_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MainActivity_Helper")
                 .imports(
                         input, "I",
                         BundleWrapper.class,
@@ -150,17 +163,17 @@ public final class ExtraTest extends BaseTest {
                         Intent.class
                 )
                 .body(
-                        "abstract class $T {",
+                        ABSTRACT_CLASS_T,
                         "",
                         "   @Weave(into = \"onCreate\", args = {\"android.os.Bundle\"}, statement = \"com.example.$T.inject(this);\")",
                         "   public static void inject($I target) {",
                         "       Intent intent = target.getIntent();",
-                        "       if (intent == null || intent.getExtras() == null) {",
-                        "           return;",
-                        "       }",
-                        "       BundleWrapper extras = BundleWrapper.from(intent.getExtras());",
-                        "       target.mExtraString = extras.get(\"<Extra-mExtraString>\", target.mExtraString);",
-                        "       target.mA = extras.get(\"<Extra-mA>\", target.mA);",
+                        IF_INTENT_NULL_INTENT_GET_EXTRAS_NULL,
+                        RETURN,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_EXTRAS_BUNDLE_WRAPPER_FROM_INTENT_GET_EXTRAS,
+                        TARGET_M_EXTRA_STRING_EXTRAS_GET_EXTRA_M_EXTRA_STRING_TARGET_M_EXTRA_STRING,
+                        TARGET_M_A_EXTRAS_GET_EXTRA_M_A_TARGET_M_A,
                         "   }",
                         "",
                         "}"
@@ -175,7 +188,7 @@ public final class ExtraTest extends BaseTest {
 
     @Test
     public void serviceOne() {
-        JavaFileObject input = file("com.example", "SomeService")
+        JavaFileObject input = file(COM_EXAMPLE, "SomeService")
                 .imports(
                         Extra.class, "E",
                         Service.class,
@@ -185,8 +198,8 @@ public final class ExtraTest extends BaseTest {
                 .body(
                         "public class $T extends Service {",
                         "",
-                        "   @$E String mExtraString;",
-                        "   @$E int mA;",
+                        E_STRING_M_EXTRA_STRING,
+                        E_INT_M_A,
                         "",
                         "   public IBinder onBind(Intent intent) {",
                         "       return null;",
@@ -195,7 +208,7 @@ public final class ExtraTest extends BaseTest {
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "SomeService_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "SomeService_Helper")
                 .imports(
                         input, "I",
                         BundleWrapper.class,
@@ -203,16 +216,16 @@ public final class ExtraTest extends BaseTest {
                         Weave.class
                 )
                 .body(
-                        "abstract class $T {",
+                        ABSTRACT_CLASS_T,
                         "",
                         "   @Weave(into = \"onStartCommand\", args = {\"android.content.Intent\", \"int\", \"int\"}, statement = \"com.example.$T.inject(this, $1);\")",
                         "   public static void inject($I target, Intent intent) {",
-                        "       if (intent == null || intent.getExtras() == null) {",
-                        "           return;",
-                        "       }",
-                        "       BundleWrapper extras = BundleWrapper.from(intent.getExtras());",
-                        "       target.mExtraString = extras.get(\"<Extra-mExtraString>\", target.mExtraString);",
-                        "       target.mA = extras.get(\"<Extra-mA>\", target.mA);",
+                        IF_INTENT_NULL_INTENT_GET_EXTRAS_NULL,
+                        RETURN,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_EXTRAS_BUNDLE_WRAPPER_FROM_INTENT_GET_EXTRAS,
+                        TARGET_M_EXTRA_STRING_EXTRAS_GET_EXTRA_M_EXTRA_STRING_TARGET_M_EXTRA_STRING,
+                        TARGET_M_A_EXTRAS_GET_EXTRA_M_A_TARGET_M_A,
                         "   }",
                         "",
                         "}"
@@ -227,7 +240,7 @@ public final class ExtraTest extends BaseTest {
 
     @Test
     public void intentServiceOne() {
-        JavaFileObject input = file("com.example", "SomeService")
+        JavaFileObject input = file(COM_EXAMPLE, "SomeService")
                 .imports(
                         Extra.class, "E",
                         IntentService.class,
@@ -238,7 +251,7 @@ public final class ExtraTest extends BaseTest {
                         "public class $T extends IntentService {",
                         "",
                         "   @$E String mExtraString;",
-                        "   @$E int mA;",
+                        E_INT_M_A,
                         "",
                         "   public $T() {super(\"Test\");}",
                         "",
@@ -248,7 +261,7 @@ public final class ExtraTest extends BaseTest {
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "SomeService_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "SomeService_Helper")
                 .imports(
                         input, "I",
                         BundleWrapper.class,
@@ -256,16 +269,16 @@ public final class ExtraTest extends BaseTest {
                         Weave.class
                 )
                 .body(
-                        "abstract class $T {",
+                        ABSTRACT_CLASS_T,
                         "",
                         "   @Weave(into = \"onHandleIntent\", args = {\"android.content.Intent\"}, statement = \"com.example.$T.inject(this, $1);\")",
                         "   public static void inject($I target, Intent intent) {",
-                        "       if (intent == null || intent.getExtras() == null) {",
-                        "           return;",
-                        "       }",
-                        "       BundleWrapper extras = BundleWrapper.from(intent.getExtras());",
-                        "       target.mExtraString = extras.get(\"<Extra-mExtraString>\", target.mExtraString);",
-                        "       target.mA = extras.get(\"<Extra-mA>\", target.mA);",
+                        IF_INTENT_NULL_INTENT_GET_EXTRAS_NULL,
+                        RETURN,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_EXTRAS_BUNDLE_WRAPPER_FROM_INTENT_GET_EXTRAS,
+                        TARGET_M_EXTRA_STRING_EXTRAS_GET_EXTRA_M_EXTRA_STRING_TARGET_M_EXTRA_STRING,
+                        TARGET_M_A_EXTRAS_GET_EXTRA_M_A_TARGET_M_A,
                         "   }",
                         "",
                         "}"

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/extra/IntentManagerTest.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/extra/IntentManagerTest.java
@@ -26,9 +26,23 @@ import static eu.f3rog.blade.compiler.util.File.generatedFile;
  */
 public final class IntentManagerTest extends BaseTest {
 
+    public static final String COM_EXAMPLE = "com.example";
+    public static final String BLADE = "blade";
+    public static final String PUBLIC_CLASS_T = "public class $T {";
+    public static final String GF_A_CLASS = "   @$GF($A.class)";
+    public static final String INTENT_INTENT_NEW_INTENT_CONTEXT_A_CLASS = "       Intent intent = new Intent(context, $A.class);";
+    public static final String BW_EXTRAS_NEW_BW = "       $BW extras = new $BW();";
+    public static final String INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE = "       intent.putExtras(extras.getBundle());";
+    public static final String RETURN_INTENT = "       return intent;";
+    public static final String PUBLIC_CLASS_T_EXTENDS_ACTIVITY = "public class $T extends Activity {";
+    public static final String E_INT_NUMBER = "   @$E int number;";
+    public static final String E_STRING_TEXT = "   @$E String text;";
+    public static final String EXTRAS_PUT_EXTRA_NUMBER_NUMBER = "       extras.put(\"<Extra-number>\", number);";
+    public static final String EXTRAS_PUT_EXTRA_TEXT_TEXT = "       extras.put(\"<Extra-text>\", text);";
+
     @Test
     public void activityNone() {
-        JavaFileObject input = file("com.example", "SomeActivity")
+        JavaFileObject input = file(COM_EXAMPLE, "SomeActivity")
                 .imports(
                         Blade.class, "B",
                         Activity.class
@@ -38,7 +52,7 @@ public final class IntentManagerTest extends BaseTest {
                         "public class $T extends Activity {}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "I")
+        JavaFileObject expected = generatedFile(BLADE, "I")
                 .imports(
                         GeneratedFor.class, "GF",
                         input, "A",
@@ -47,17 +61,17 @@ public final class IntentManagerTest extends BaseTest {
                         Context.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static Intent for$A(Context context) {",
-                        "       Intent intent = new Intent(context, $A.class);",
-                        "       $BW extras = new $BW();",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        INTENT_INTENT_NEW_INTENT_CONTEXT_A_CLASS,
+                        BW_EXTRAS_NEW_BW,
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static void start$A(Context context) {",
                         "       context.startActivity(for$A(context));",
                         "   }",
@@ -74,20 +88,20 @@ public final class IntentManagerTest extends BaseTest {
 
     @Test
     public void activityOne() {
-        JavaFileObject input = file("com.example", "SomeActivity")
+        JavaFileObject input = file(COM_EXAMPLE, "SomeActivity")
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
                         "   @$E String mText;",
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "I")
+        JavaFileObject expected = generatedFile(BLADE, "I")
                 .imports(
                         GeneratedFor.class, "GF",
                         input, "A",
@@ -97,18 +111,18 @@ public final class IntentManagerTest extends BaseTest {
                         Context.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static Intent for$A(Context context, String mText) {",
-                        "       Intent intent = new Intent(context, $A.class);",
-                        "       $BW extras = new $BW();",
+                        INTENT_INTENT_NEW_INTENT_CONTEXT_A_CLASS,
+                        BW_EXTRAS_NEW_BW,
                         "       extras.put(\"<Extra-mText>\", mText);",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static void start$A(Context context, String mText) {",
                         "       context.startActivity(for$A(context, mText));",
                         "   }",
@@ -125,34 +139,34 @@ public final class IntentManagerTest extends BaseTest {
 
     @Test
     public void activityMore() {
-        JavaFileObject input1 = file("com.example", "FirstActivity")
+        JavaFileObject input1 = file(COM_EXAMPLE, "FirstActivity")
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
-                        "   @$E int number;",
+                        E_INT_NUMBER,
                         "",
                         "}"
                 );
-        JavaFileObject input2 = file("com.example", "SecondActivity")
+        JavaFileObject input2 = file(COM_EXAMPLE, "SecondActivity")
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
-                        "   @$E String text;",
+                        E_STRING_TEXT,
                         "   @$E boolean flag;",
                         "   @$E double number;",
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "I")
+        JavaFileObject expected = generatedFile(BLADE, "I")
                 .imports(
                         GeneratedFor.class, "GF",
                         input1, "A1",
@@ -163,15 +177,15 @@ public final class IntentManagerTest extends BaseTest {
                         Context.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   @$GF($A1.class)",
                         "   public static Intent for$A1(Context context, int number) {",
                         "       Intent intent = new Intent(context, $A1.class);",
-                        "       $BW extras = new $BW();",
-                        "       extras.put(\"<Extra-number>\", number);",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        BW_EXTRAS_NEW_BW,
+                        EXTRAS_PUT_EXTRA_NUMBER_NUMBER,
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
                         "   @$GF($A1.class)",
@@ -182,12 +196,12 @@ public final class IntentManagerTest extends BaseTest {
                         "   @$GF($A2.class)",
                         "   public static Intent for$A2(Context context, String text, boolean flag, double number) {",
                         "       Intent intent = new Intent(context, $A2.class);",
-                        "       $BW extras = new $BW();",
-                        "       extras.put(\"<Extra-text>\", text);",
+                        BW_EXTRAS_NEW_BW,
+                        EXTRAS_PUT_EXTRA_TEXT_TEXT,
                         "       extras.put(\"<Extra-flag>\", flag);",
-                        "       extras.put(\"<Extra-number>\", number);",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        EXTRAS_PUT_EXTRA_NUMBER_NUMBER,
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
                         "   @$GF($A2.class)",
@@ -207,19 +221,19 @@ public final class IntentManagerTest extends BaseTest {
 
     @Test
     public void activityInheritance() {
-        JavaFileObject base = file("com.example", "BaseActivity")
+        JavaFileObject base = file(COM_EXAMPLE, "BaseActivity")
                 .imports(
                         Extra.class, "E",
                         Activity.class
                 )
                 .body(
-                        "public class $T extends Activity {",
+                        PUBLIC_CLASS_T_EXTENDS_ACTIVITY,
                         "",
-                        "   @$E int number;",
+                        E_INT_NUMBER,
                         "",
                         "}"
                 );
-        JavaFileObject activity = file("com.example", "MyActivity")
+        JavaFileObject activity = file(COM_EXAMPLE, "MyActivity")
                 .imports(
                         Extra.class, "E",
                         base, "B"
@@ -227,12 +241,12 @@ public final class IntentManagerTest extends BaseTest {
                 .body(
                         "public class $T extends $B {",
                         "",
-                        "   @$E String text;",
+                        E_STRING_TEXT,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "I")
+        JavaFileObject expected = generatedFile(BLADE, "I")
                 .imports(
                         GeneratedFor.class, "GF",
                         base, "B",
@@ -243,15 +257,15 @@ public final class IntentManagerTest extends BaseTest {
                         Context.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   @$GF($B.class)",
                         "   public static Intent for$B(Context context, int number) {",
                         "       Intent intent = new Intent(context, $B.class);",
-                        "       $BW extras = new $BW();",
-                        "       extras.put(\"<Extra-number>\", number);",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        BW_EXTRAS_NEW_BW,
+                        EXTRAS_PUT_EXTRA_NUMBER_NUMBER,
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
                         "   @$GF($B.class)",
@@ -259,17 +273,17 @@ public final class IntentManagerTest extends BaseTest {
                         "       context.startActivity(for$B(context, number));",
                         "   }",
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static Intent for$A(Context context, int number, String text) {",
-                        "       Intent intent = new Intent(context, $A.class);",
-                        "       $BW extras = new $BW();",
-                        "       extras.put(\"<Extra-number>\", number);",
-                        "       extras.put(\"<Extra-text>\", text);",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        INTENT_INTENT_NEW_INTENT_CONTEXT_A_CLASS,
+                        BW_EXTRAS_NEW_BW,
+                        EXTRAS_PUT_EXTRA_NUMBER_NUMBER,
+                        EXTRAS_PUT_EXTRA_TEXT_TEXT,
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static void start$A(Context context, int number, String text) {",
                         "       context.startActivity(for$A(context, number, text));",
                         "   }",
@@ -286,7 +300,7 @@ public final class IntentManagerTest extends BaseTest {
 
     @Test
     public void activityInheritanceFromAbstract() {
-        JavaFileObject base = file("com.example", "BaseActivity")
+        JavaFileObject base = file(COM_EXAMPLE, "BaseActivity")
                 .imports(
                         Extra.class, "E",
                         Activity.class
@@ -294,11 +308,11 @@ public final class IntentManagerTest extends BaseTest {
                 .body(
                         "public abstract class $T extends Activity {",
                         "",
-                        "   @$E int number;",
+                        E_INT_NUMBER,
                         "",
                         "}"
                 );
-        JavaFileObject activity = file("com.example", "MyActivity")
+        JavaFileObject activity = file(COM_EXAMPLE, "MyActivity")
                 .imports(
                         Extra.class, "E",
                         base, "B"
@@ -306,12 +320,12 @@ public final class IntentManagerTest extends BaseTest {
                 .body(
                         "public class $T extends $B {",
                         "",
-                        "   @$E String text;",
+                        E_STRING_TEXT,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("blade", "I")
+        JavaFileObject expected = generatedFile(BLADE, "I")
                 .imports(
                         GeneratedFor.class, "GF",
                         activity, "A",
@@ -321,19 +335,19 @@ public final class IntentManagerTest extends BaseTest {
                         Context.class
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static Intent for$A(Context context, int number, String text) {",
-                        "       Intent intent = new Intent(context, $A.class);",
-                        "       $BW extras = new $BW();",
-                        "       extras.put(\"<Extra-number>\", number);",
-                        "       extras.put(\"<Extra-text>\", text);",
-                        "       intent.putExtras(extras.getBundle());",
-                        "       return intent;",
+                        INTENT_INTENT_NEW_INTENT_CONTEXT_A_CLASS,
+                        BW_EXTRAS_NEW_BW,
+                        EXTRAS_PUT_EXTRA_NUMBER_NUMBER,
+                        EXTRAS_PUT_EXTRA_TEXT_TEXT,
+                        INTENT_PUT_EXTRAS_EXTRAS_GET_BUNDLE,
+                        RETURN_INTENT,
                         "   }",
                         "",
-                        "   @$GF($A.class)",
+                        GF_A_CLASS,
                         "   public static void start$A(Context context, int number, String text) {",
                         "       context.startActivity(for$A(context, number, text));",
                         "   }",

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/mvp/PresenterTest.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/mvp/PresenterTest.java
@@ -31,25 +31,51 @@ import static eu.f3rog.blade.compiler.util.File.generatedFile;
 public final class PresenterTest extends BaseTest {
 
     private static final String PRESENTER_METHODS =
-            " public void bind(%s view) {} " +
-                    " public void unbind() {} " +
-                    " public void create(%s o, boolean wasRestored) {} " +
-                    " public void destroy() {} " +
-                    " public void saveState(Object o) {} " +
-                    " public void restoreState(Object o) {} ";
+        " public void bind(%s view) {} " +
+                " public void unbind() {} " +
+                " public void create(%s o, boolean wasRestored) {} " +
+                " public void destroy() {} " +
+                " public void saveState(Object o) {} " +
+                " public void restoreState(Object o) {} ";
+    public static final String MY_CLASS = "MyClass";
+    public static final String COM_EXAMPLE = "com.example";
+    public static final String P_OBJECT_O = "   @$P Object o;";
+    public static final String PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V = "public class $T extends View implements $V {";
+    public static final String PUBLIC_T_CONTEXT_C_SUPER_C = "   public $T(Context c) {super(c);}";
+    public static final String STRING = "String";
+    public static final String MY_PRESENTER = "MyPresenter";
+    public static final String P_MP_M_PRESENTER = "   @$P $MP mPresenter;";
+    public static final String IF_TAG_OBJECT_NULL = "       if (tagObject == null) {";
+    public static final String IF_TARGET_M_PRESENTER_NULL_1 = "           if (target.mPresenter != null) {";
+    public static final String TARGET_M_PRESENTER_UNBIND = "               target.mPresenter.unbind();";
+    public static final String TARGET_M_PRESENTER_NULL = "           target.mPresenter = null;";
+    public static final String ELSE = "       } else {";
+    public static final String IF_TAG_OBJECT_INSTANCEOF_STRING = "           if (!(tagObject instanceof String)) {";
+    public static final String THROW_NEW_E_INCORRECT_TYPE_OF_TAG_OBJECT = "               throw new $E(\"Incorrect type of tag object.\");";
+    public static final String STRING_PARAM_STRING_TAG_OBJECT = "           String param = (String) tagObject;";
+    public static final String TARGET_M_PRESENTER_P_PM_GET_TARGET_PARAM_P_CLASS = "           target.mPresenter = ($P) $PM.get(target, param, $P.class);";
+    public static final String IF_TARGET_M_PRESENTER_NULL_2 = "           if (target.mPresenter == null) {";
+    public static final String TARGET_M_PRESENTER_NEW_P = "               target.mPresenter = new $P();";
+    public static final String PM_PUT_TARGET_PARAM_TARGET_M_PRESENTER = "               $PM.put(target, param, target.mPresenter);";
+    public static final String CLOSING_BRACE_1 = "       }";
+    public static final String IF_TARGET_M_PRESENTER_NULL_3 = "       if (target.mPresenter != null) {";
+    public static final String TARGET_M_PRESENTER_BIND_TARGET = "           target.mPresenter.bind(target);";
+    public static final String CLOSING_BRACE_2 = "   }";
+    public static final String CLOSING_BRACE_3 = "           }";
+    public static final String CLOSING_BRACE_4 = "}";
 
     @Test
     public void invalidClass() {
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         Presenter.class, "P"
                 )
                 .body(
                         "public class $T {",
                         "",
-                        "   @$P Object o;",
+                        P_OBJECT_O,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(input)
@@ -57,7 +83,7 @@ public final class PresenterTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(MvpErrorMsg.Invalid_class_with_Presenter);
 
-        input = file("com.example", "MyClass")
+        input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         Presenter.class, "P",
                         View.class
@@ -65,9 +91,9 @@ public final class PresenterTest extends BaseTest {
                 .body(
                         "public class $T extends View {",
                         "",
-                        "   @$P Object o;",
+                        P_OBJECT_O,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(input)
@@ -78,7 +104,7 @@ public final class PresenterTest extends BaseTest {
 
     @Test
     public void invalidField() {
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         View.class,
                         Context.class,
@@ -86,13 +112,13 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
                         "   @$P private Object o;",
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(input)
@@ -100,7 +126,7 @@ public final class PresenterTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, Presenter.class.getSimpleName()));
 
-        input = file("com.example", "MyClass")
+        input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         View.class,
                         Context.class,
@@ -108,13 +134,13 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
                         "   @$P protected Object o;",
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(input)
@@ -122,7 +148,7 @@ public final class PresenterTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, Presenter.class.getSimpleName()));
 
-        input = file("com.example", "MyClass")
+        input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         View.class,
                         Context.class,
@@ -130,13 +156,13 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
                         "   @$P final Object o;",
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(input)
@@ -147,7 +173,7 @@ public final class PresenterTest extends BaseTest {
 
     @Test
     public void invalidPresenterClass() {
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         View.class,
                         Context.class,
@@ -155,13 +181,13 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
-                        "   @$P Object o;",
+                        P_OBJECT_O,
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(input)
@@ -172,7 +198,7 @@ public final class PresenterTest extends BaseTest {
 
     @Test
     public void inconsistentPresenterParameterTypes() {
-        JavaFileObject presenter1 = file("com.example", "MyPresenter1")
+        JavaFileObject presenter1 = file(COM_EXAMPLE, "MyPresenter1")
                 .imports(
                         IPresenter.class, "P",
                         IView.class, "V"
@@ -182,9 +208,9 @@ public final class PresenterTest extends BaseTest {
                         "",
                         String.format(PRESENTER_METHODS, "$V", "Long"),
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
-        JavaFileObject presenter2 = file("com.example", "MyPresenter2")
+        JavaFileObject presenter2 = file(COM_EXAMPLE, "MyPresenter2")
                 .imports(
                         IPresenter.class, "P",
                         IView.class, "V"
@@ -192,11 +218,11 @@ public final class PresenterTest extends BaseTest {
                 .body(
                         "public class $T implements $P<$V, String> {",
                         "",
-                        String.format(PRESENTER_METHODS, "$V", "String"),
+                        String.format(PRESENTER_METHODS, "$V", STRING),
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         presenter1, "MP1",
                         presenter2, "MP2",
@@ -206,14 +232,14 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
                         "   @$P $MP1 mPresenter1;",
                         "   @$P $MP2 mPresenter2;",
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(presenter1, presenter2, input)
@@ -224,7 +250,7 @@ public final class PresenterTest extends BaseTest {
 
     @Test
     public void oneViewPresenter() {
-        JavaFileObject presenter = file("com.example", "MyPresenter")
+        JavaFileObject presenter = file(COM_EXAMPLE, MY_PRESENTER)
                 .imports(
                         IPresenter.class, "P",
                         "com.example.MyView", "V"
@@ -232,11 +258,11 @@ public final class PresenterTest extends BaseTest {
                 .body(
                         "public class $T implements $P<$V, String> {",
                         "",
-                        String.format(PRESENTER_METHODS, "$V", "String"),
+                        String.format(PRESENTER_METHODS, "$V", STRING),
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
-        JavaFileObject view = file("com.example", "MyView")
+        JavaFileObject view = file(COM_EXAMPLE, "MyView")
                 .imports(
                         presenter, "MP",
                         View.class,
@@ -245,16 +271,16 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
-                        "   @$P $MP mPresenter;",
+                        P_MP_M_PRESENTER,
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MyView_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MyView_Helper")
                 .imports(
                         PresenterManager.class, "PM",
                         presenter, "P",
@@ -272,41 +298,41 @@ public final class PresenterTest extends BaseTest {
                         "",
                         "   @Weave(into = \"setTag\", args = {\"java.lang.Object\"}, statement = \"String tag = com.example.$T.setPresenters(this, $1); super.setTag(tag); if (this.mIsAttached) { com.example.$T.bindPresenters(this); } return;\")",
                         "   public static String setPresenters($V target, Object tagObject) {",
-                        "       if (tagObject == null) {",
-                        "           if (target.mPresenter != null) {",
-                        "               target.mPresenter.unbind();",
-                        "           }",
-                        "           target.mPresenter = null;",
+                        IF_TAG_OBJECT_NULL,
+                        IF_TARGET_M_PRESENTER_NULL_1,
+                        TARGET_M_PRESENTER_UNBIND,
+                        CLOSING_BRACE_1,
+                        TARGET_M_PRESENTER_NULL,
                         "           return null;",
-                        "       } else {",
-                        "           if (!(tagObject instanceof String)) {",
-                        "               throw new $E(\"Incorrect type of tag object.\");",
-                        "           }",
-                        "           String param = (String) tagObject;",
-                        "           target.mPresenter = ($P) $PM.get(target, param, $P.class);",
-                        "           if (target.mPresenter == null) {",
-                        "               target.mPresenter = new $P();",
-                        "               $PM.put(target, param, target.mPresenter);",
-                        "           }",
+                        ELSE,
+                        IF_TAG_OBJECT_INSTANCEOF_STRING,
+                        THROW_NEW_E_INCORRECT_TYPE_OF_TAG_OBJECT,
+                        CLOSING_BRACE_3,
+                        STRING_PARAM_STRING_TAG_OBJECT,
+                        TARGET_M_PRESENTER_P_PM_GET_TARGET_PARAM_P_CLASS,
+                        IF_TARGET_M_PRESENTER_NULL_2,
+                        TARGET_M_PRESENTER_NEW_P,
+                        PM_PUT_TARGET_PARAM_TARGET_M_PRESENTER,
+                        CLOSING_BRACE_3,
                         "           return tagObject.toString();",
-                        "       }",
-                        "   }",
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
                         "   @Weave(into = \"onAttachedToWindow\", statement = \"com.example.$T.bindPresenters(this); this.mIsAttached = true;\")",
                         "   public static void bindPresenters($V target) {",
-                        "       if (target.mPresenter != null) {",
-                        "           target.mPresenter.bind(target);",
-                        "       }",
-                        "   }",
+                        IF_TARGET_M_PRESENTER_NULL_3,
+                        TARGET_M_PRESENTER_BIND_TARGET,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
                         "   @Weave(into = \"onDetachedFromWindow\", statement = \"com.example.$T.unbindPresenters(this); this.mIsAttached = false;\")",
                         "   public static void unbindPresenters($V target) {",
-                        "       if (target.mPresenter != null) {",
-                        "           target.mPresenter.unbind();",
-                        "       }",
-                        "   }",
+                        IF_TARGET_M_PRESENTER_NULL_3,
+                        TARGET_M_PRESENTER_UNBIND,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(presenter, view)
@@ -318,7 +344,7 @@ public final class PresenterTest extends BaseTest {
 
     @Test
     public void oneViewBasePresenter() {
-        JavaFileObject presenter = file("com.example", "MyPresenter")
+        JavaFileObject presenter = file(COM_EXAMPLE, MY_PRESENTER)
                 .imports(
                         BasePresenter.class, "P",
                         "com.example.MyView", "V"
@@ -326,9 +352,9 @@ public final class PresenterTest extends BaseTest {
                 .body(
                         "public class $T extends $P<$V, String> {",
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
-        JavaFileObject view = file("com.example", "MyView")
+        JavaFileObject view = file(COM_EXAMPLE, "MyView")
                 .imports(
                         presenter, "MP",
                         View.class,
@@ -337,16 +363,16 @@ public final class PresenterTest extends BaseTest {
                         IView.class, "V"
                 )
                 .body(
-                        "public class $T extends View implements $V {",
+                        PUBLIC_CLASS_T_EXTENDS_VIEW_IMPLEMENTS_V,
                         "",
-                        "   @$P $MP mPresenter;",
+                        P_MP_M_PRESENTER,
                         "",
-                        "   public $T(Context c) {super(c);}",
+                        PUBLIC_T_CONTEXT_C_SUPER_C,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MyView_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MyView_Helper")
                 .imports(
                         PresenterManager.class, "PM",
                         presenter, "P",
@@ -364,41 +390,41 @@ public final class PresenterTest extends BaseTest {
                         "",
                         "   @Weave(into = \"setTag\", args = {\"java.lang.Object\"}, statement = \"String tag = com.example.$T.setPresenters(this, $1); super.setTag(tag); if (this.mIsAttached) { com.example.$T.bindPresenters(this); } return;\")",
                         "   public static String setPresenters($V target, Object tagObject) {",
-                        "       if (tagObject == null) {",
-                        "           if (target.mPresenter != null) {",
-                        "               target.mPresenter.unbind();",
-                        "           }",
-                        "           target.mPresenter = null;",
+                        IF_TAG_OBJECT_NULL,
+                        IF_TARGET_M_PRESENTER_NULL_1,
+                        TARGET_M_PRESENTER_UNBIND,
+                        CLOSING_BRACE_3,
+                        TARGET_M_PRESENTER_NULL,
                         "           return null;",
-                        "       } else {",
-                        "           if (!(tagObject instanceof String)) {",
-                        "               throw new $E(\"Incorrect type of tag object.\");",
-                        "           }",
-                        "           String param = (String) tagObject;",
-                        "           target.mPresenter = ($P) $PM.get(target, param, $P.class);",
-                        "           if (target.mPresenter == null) {",
-                        "               target.mPresenter = new $P();",
-                        "               $PM.put(target, param, target.mPresenter);",
-                        "           }",
+                        ELSE,
+                        IF_TAG_OBJECT_INSTANCEOF_STRING,
+                        THROW_NEW_E_INCORRECT_TYPE_OF_TAG_OBJECT,
+                        CLOSING_BRACE_3,
+                        STRING_PARAM_STRING_TAG_OBJECT,
+                        TARGET_M_PRESENTER_P_PM_GET_TARGET_PARAM_P_CLASS,
+                        IF_TARGET_M_PRESENTER_NULL_2,
+                        TARGET_M_PRESENTER_NEW_P,
+                        PM_PUT_TARGET_PARAM_TARGET_M_PRESENTER,
+                        CLOSING_BRACE_3,
                         "           return tagObject.toString();",
-                        "       }",
-                        "   }",
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
                         "   @Weave(into = \"onAttachedToWindow\", statement = \"com.example.$T.bindPresenters(this); this.mIsAttached = true;\")",
                         "   public static void bindPresenters($V target) {",
-                        "       if (target.mPresenter != null) {",
-                        "           target.mPresenter.bind(target);",
-                        "       }",
-                        "   }",
+                        IF_TARGET_M_PRESENTER_NULL_3,
+                        TARGET_M_PRESENTER_BIND_TARGET,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
                         "   @Weave(into = \"onDetachedFromWindow\", statement = \"com.example.$T.unbindPresenters(this); this.mIsAttached = false;\")",
                         "   public static void unbindPresenters($V target) {",
-                        "       if (target.mPresenter != null) {",
-                        "           target.mPresenter.unbind();",
-                        "       }",
-                        "   }",
+                        IF_TARGET_M_PRESENTER_NULL_3,
+                        TARGET_M_PRESENTER_UNBIND,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(presenter, view)
@@ -410,15 +436,15 @@ public final class PresenterTest extends BaseTest {
 
     @Test
     public void oneActivityPresenter() {
-        JavaFileObject viewInterface = file("com.example", "IMyView")
+        JavaFileObject viewInterface = file(COM_EXAMPLE, "IMyView")
                 .imports(
                         IView.class, "V"
                 )
                 .body(
                         "public interface $T extends $V {",
-                        "}"
+                        CLOSING_BRACE_4
                 );
-        JavaFileObject presenter = file("com.example", "MyPresenter")
+        JavaFileObject presenter = file(COM_EXAMPLE, MY_PRESENTER)
                 .imports(
                         IPresenter.class, "P",
                         viewInterface, "MV"
@@ -426,11 +452,11 @@ public final class PresenterTest extends BaseTest {
                 .body(
                         "public class $T implements $P<$MV, String> {",
                         "",
-                        String.format(PRESENTER_METHODS, "$MV", "String"),
+                        String.format(PRESENTER_METHODS, "$MV", STRING),
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
-        JavaFileObject activity = file("com.example", "MyActivity")
+        JavaFileObject activity = file(COM_EXAMPLE, "MyActivity")
                 .imports(
                         Activity.class,
                         viewInterface, "MV",
@@ -441,14 +467,14 @@ public final class PresenterTest extends BaseTest {
                 .body(
                         "public class $T extends Activity implements $MV {",
                         "",
-                        "   @$P $MP mPresenter;",
+                        P_MP_M_PRESENTER,
                         "",
                         "   public void setTag(Object o) {}",
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MyActivity_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MyActivity_Helper")
                 .imports(
                         Weave.class,
                         activity, "A",
@@ -464,38 +490,38 @@ public final class PresenterTest extends BaseTest {
                         "",
                         "   @Weave(into = \"setTag\", args = {\"java.lang.Object\"}, statement = \"com.example.$T.setPresenters(this, $1); com.example.$T.bindPresenters(this);\")",
                         "   public static void setPresenters($A target, Object tagObject) {",
-                        "       if (tagObject == null) {",
-                        "           if (target.mPresenter != null) {",
-                        "               target.mPresenter.unbind();",
-                        "           }",
-                        "           target.mPresenter = null;",
-                        "       } else {",
-                        "           if (!(tagObject instanceof String)) {",
-                        "               throw new $E(\"Incorrect type of tag object.\");",
-                        "           }",
-                        "           String param = (String) tagObject;",
-                        "           target.mPresenter = ($P) $PM.get(target, param, $P.class);",
-                        "           if (target.mPresenter == null) {",
-                        "               target.mPresenter = new $P();",
-                        "               $PM.put(target, param, target.mPresenter);",
-                        "           }",
-                        "       }",
-                        "   }",
+                        IF_TAG_OBJECT_NULL,
+                        IF_TARGET_M_PRESENTER_NULL_1,
+                        TARGET_M_PRESENTER_UNBIND,
+                        CLOSING_BRACE_3,
+                        TARGET_M_PRESENTER_NULL,
+                        ELSE,
+                        IF_TAG_OBJECT_INSTANCEOF_STRING,
+                        THROW_NEW_E_INCORRECT_TYPE_OF_TAG_OBJECT,
+                        CLOSING_BRACE_3,
+                        STRING_PARAM_STRING_TAG_OBJECT,
+                        TARGET_M_PRESENTER_P_PM_GET_TARGET_PARAM_P_CLASS,
+                        IF_TARGET_M_PRESENTER_NULL_2,
+                        TARGET_M_PRESENTER_NEW_P,
+                        PM_PUT_TARGET_PARAM_TARGET_M_PRESENTER,
+                        CLOSING_BRACE_3,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
                         "   public static void bindPresenters($A target) {",
-                        "       if (target.mPresenter != null) {",
-                        "           target.mPresenter.bind(target);",
-                        "       }",
-                        "   }",
+                        IF_TARGET_M_PRESENTER_NULL_3,
+                        TARGET_M_PRESENTER_BIND_TARGET,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
                         "   @Weave(into = \"onDestroy\", statement = \"com.example.$T.unbindPresenters(this);\")",
                         "   public static void unbindPresenters($A target) {",
-                        "       if (target.mPresenter != null) {",
-                        "           target.mPresenter.unbind();",
-                        "       }",
-                        "   }",
+                        IF_TARGET_M_PRESENTER_NULL_3,
+                        TARGET_M_PRESENTER_UNBIND,
+                        CLOSING_BRACE_1,
+                        CLOSING_BRACE_2,
                         "",
-                        "}"
+                        CLOSING_BRACE_4
                 );
 
         assertFiles(viewInterface, presenter, activity)

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/state/StateTest.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/state/StateTest.java
@@ -29,14 +29,32 @@ import static eu.f3rog.blade.compiler.util.File.generatedFile;
  */
 public final class StateTest extends BaseTest {
 
+    public static final String MY_CLASS = "MyClass";
+    public static final String COM_EXAMPLE = "com.example";
+    public static final String PUBLIC_CLASS_T = "public class $T {";
+    public static final String S_STRING_M_TEXT = "   @$S String mText;";
+    public static final String S_INT_M_NUMBER = "   @$S int mNumber;";
+    public static final String ABSTRACT_CLASS_T = "abstract class $T {";
+    public static final String PUBLIC_STATIC_VOID_SAVE_STATE_I_TARGET_BUNDLE_STATE = "   public static void saveState($I target, Bundle state) {";
+    public static final String IF_STATE_NULL = "       if (state == null) {";
+    public static final String THROW_NEW_E_STATE_CANNOT_BE_NULL = "           throw new $E(\"State cannot be null!\");";
+    public static final String CLOSING_BRACE = "       }";
+    public static final String BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE = "       BundleWrapper bundleWrapper = BundleWrapper.from(state);";
+    public static final String BUNDLE_WRAPPER_PUT_STATEFUL_M_TEXT_TARGET_M_TEXT = "       bundleWrapper.put(\"<Stateful-mText>\", target.mText);";
+    public static final String BUNDLE_WRAPPER_PUT_STATEFUL_M_NUMBER_TARGET_M_NUMBER = "       bundleWrapper.put(\"<Stateful-mNumber>\", target.mNumber);";
+    public static final String PUBLIC_STATIC_VOID_RESTORE_STATE_I_TARGET_BUNDLE_STATE = "   public static void restoreState($I target, Bundle state) {";
+    public static final String RETURN = "           return;";
+    public static final String TARGET_M_TEXT_BUNDLE_WRAPPER_GET_STATEFUL_M_TEXT_TARGET_M_TEXT = "       target.mText = bundleWrapper.get(\"<Stateful-mText>\", target.mText);";
+    public static final String TARGET_M_NUMBER_BUNDLE_WRAPPER_GET_STATEFUL_M_NUMBER_TARGET_M_NUMBER = "       target.mNumber = bundleWrapper.get(\"<Stateful-mNumber>\", target.mNumber);";
+
     @Test
     public void invalidField() {
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         State.class, "S"
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   @$S private String mText;",
                         "",
@@ -48,12 +66,12 @@ public final class StateTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, State.class.getSimpleName()));
 
-        input = file("com.example", "MyClass")
+        input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         State.class, "S"
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   @$S protected String mText;",
                         "",
@@ -65,12 +83,12 @@ public final class StateTest extends BaseTest {
                 .failsToCompile()
                 .withErrorContaining(String.format(ErrorMsg.Invalid_field_with_annotation, State.class.getSimpleName()));
 
-        input = file("com.example", "MyClass")
+        input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         State.class, "S"
                 )
                 .body(
-                        "public class $T {",
+                        PUBLIC_CLASS_T,
                         "",
                         "   @$S final String mText;",
                         "",
@@ -85,7 +103,7 @@ public final class StateTest extends BaseTest {
 
     @Test
     public void activity() {
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         Activity.class,
                         State.class, "S"
@@ -93,13 +111,13 @@ public final class StateTest extends BaseTest {
                 .body(
                         "public class $T extends Activity {",
                         "",
-                        "   @$S String mText;",
-                        "   @$S int mNumber;",
+                        S_STRING_M_TEXT,
+                        S_INT_M_NUMBER,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MyClass_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MyClass_Helper")
                 .imports(
                         input, "I",
                         Bundle.class,
@@ -108,26 +126,26 @@ public final class StateTest extends BaseTest {
                         Weave.class
                 )
                 .body(
-                        "abstract class $T {",
+                        ABSTRACT_CLASS_T,
                         "",
                         "   @Weave(into = \"onSaveInstanceState\", args = {\"android.os.Bundle\"}, statement = \"com.example.$T.saveState(this, $1);\")",
-                        "   public static void saveState($I target, Bundle state) {",
-                        "       if (state == null) {",
-                        "           throw new $E(\"State cannot be null!\");",
-                        "       }",
-                        "       BundleWrapper bundleWrapper = BundleWrapper.from(state);",
-                        "       bundleWrapper.put(\"<Stateful-mText>\", target.mText);",
-                        "       bundleWrapper.put(\"<Stateful-mNumber>\", target.mNumber);",
+                        PUBLIC_STATIC_VOID_SAVE_STATE_I_TARGET_BUNDLE_STATE,
+                        IF_STATE_NULL,
+                        THROW_NEW_E_STATE_CANNOT_BE_NULL,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE,
+                        BUNDLE_WRAPPER_PUT_STATEFUL_M_TEXT_TARGET_M_TEXT,
+                        BUNDLE_WRAPPER_PUT_STATEFUL_M_NUMBER_TARGET_M_NUMBER,
                         "   }",
                         "",
                         "   @Weave(into = \"onCreate\", args = {\"android.os.Bundle\"}, statement = \"com.example.$T.restoreState(this, $1);\")",
-                        "   public static void restoreState($I target, Bundle state) {",
-                        "       if (state == null) {",
-                        "           return;",
-                        "       }",
-                        "       BundleWrapper bundleWrapper = BundleWrapper.from(state);",
-                        "       target.mText = bundleWrapper.get(\"<Stateful-mText>\", target.mText);",
-                        "       target.mNumber = bundleWrapper.get(\"<Stateful-mNumber>\", target.mNumber);",
+                        PUBLIC_STATIC_VOID_RESTORE_STATE_I_TARGET_BUNDLE_STATE,
+                        IF_STATE_NULL,
+                        RETURN,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE,
+                        TARGET_M_TEXT_BUNDLE_WRAPPER_GET_STATEFUL_M_TEXT_TARGET_M_TEXT,
+                        TARGET_M_NUMBER_BUNDLE_WRAPPER_GET_STATEFUL_M_NUMBER_TARGET_M_NUMBER,
                         "   }",
                         "",
                         "}"
@@ -142,7 +160,7 @@ public final class StateTest extends BaseTest {
 
     @Test
     public void presenter() {
-        JavaFileObject input = file("com.example", "MyPresenter")
+        JavaFileObject input = file(COM_EXAMPLE, "MyPresenter")
                 .imports(
                         IPresenter.class,
                         IView.class,
@@ -151,13 +169,13 @@ public final class StateTest extends BaseTest {
                 .body(
                         "public abstract class $T implements IPresenter<IView, Object> {",
                         "",
-                        "   @$S String mText;",
-                        "   @$S int mNumber;",
+                        S_STRING_M_TEXT,
+                        S_INT_M_NUMBER,
                         "",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MyPresenter_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MyPresenter_Helper")
                 .imports(
                         input, "I",
                         Bundle.class,
@@ -166,26 +184,26 @@ public final class StateTest extends BaseTest {
                         Weave.class
                 )
                 .body(
-                        "abstract class $T {",
+                        ABSTRACT_CLASS_T,
                         "",
                         "   @Weave(into = \"saveState\", args = {\"java.lang.Object\"}, statement = \"com.example.$T.saveState(this, (android.os.Bundle) $1);\")",
-                        "   public static void saveState($I target, Bundle state) {",
-                        "       if (state == null) {",
-                        "           throw new $E(\"State cannot be null!\");",
-                        "       }",
-                        "       BundleWrapper bundleWrapper = BundleWrapper.from(state);",
-                        "       bundleWrapper.put(\"<Stateful-mText>\", target.mText);",
-                        "       bundleWrapper.put(\"<Stateful-mNumber>\", target.mNumber);",
+                        PUBLIC_STATIC_VOID_SAVE_STATE_I_TARGET_BUNDLE_STATE,
+                        IF_STATE_NULL,
+                        THROW_NEW_E_STATE_CANNOT_BE_NULL,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE,
+                        BUNDLE_WRAPPER_PUT_STATEFUL_M_TEXT_TARGET_M_TEXT,
+                        BUNDLE_WRAPPER_PUT_STATEFUL_M_NUMBER_TARGET_M_NUMBER,
                         "   }",
                         "",
                         "   @Weave(into = \"restoreState\", args = {\"java.lang.Object\"}, statement = \"com.example.$T.restoreState(this, (android.os.Bundle) $1);\")",
-                        "   public static void restoreState($I target, Bundle state) {",
-                        "       if (state == null) {",
-                        "           return;",
-                        "       }",
-                        "       BundleWrapper bundleWrapper = BundleWrapper.from(state);",
-                        "       target.mText = bundleWrapper.get(\"<Stateful-mText>\", target.mText);",
-                        "       target.mNumber = bundleWrapper.get(\"<Stateful-mNumber>\", target.mNumber);",
+                        PUBLIC_STATIC_VOID_RESTORE_STATE_I_TARGET_BUNDLE_STATE,
+                        IF_STATE_NULL,
+                        RETURN,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE,
+                        TARGET_M_TEXT_BUNDLE_WRAPPER_GET_STATEFUL_M_TEXT_TARGET_M_TEXT,
+                        TARGET_M_NUMBER_BUNDLE_WRAPPER_GET_STATEFUL_M_NUMBER_TARGET_M_NUMBER,
                         "   }",
                         "",
                         "}"
@@ -200,7 +218,7 @@ public final class StateTest extends BaseTest {
 
     @Test
     public void view() {
-        JavaFileObject input = file("com.example", "MyClass")
+        JavaFileObject input = file(COM_EXAMPLE, MY_CLASS)
                 .imports(
                         View.class,
                         Context.class,
@@ -209,14 +227,14 @@ public final class StateTest extends BaseTest {
                 .body(
                         "public class $T extends View {",
                         "",
-                        "   @$S String mText;",
-                        "   @$S int mNumber;",
+                        S_STRING_M_TEXT,
+                        S_INT_M_NUMBER,
                         "",
                         "   public $T(Context c) {super(c);}",
                         "}"
                 );
 
-        JavaFileObject expected = generatedFile("com.example", "MyClass_Helper")
+        JavaFileObject expected = generatedFile(COM_EXAMPLE, "MyClass_Helper")
                 .imports(
                         input, "I",
                         Bundle.class,
@@ -225,28 +243,28 @@ public final class StateTest extends BaseTest {
                         Weave.class
                 )
                 .body(
-                        "abstract class $T {",
+                        ABSTRACT_CLASS_T,
                         "",
                         "   @Weave(into = \"onSaveInstanceState\", ",
                         "       statement = \"android.os.Bundle bundle = new android.os.Bundle();bundle.putParcelable('PARENT_STATE', super.onSaveInstanceState());com.example.$T.saveState(this, bundle);return bundle;\")",
-                        "   public static void saveState($I target, Bundle state) {",
-                        "       if (state == null) {",
-                        "           throw new $E(\"State cannot be null!\");",
-                        "       }",
-                        "       BundleWrapper bundleWrapper = BundleWrapper.from(state);",
-                        "       bundleWrapper.put(\"<Stateful-mText>\", target.mText);",
-                        "       bundleWrapper.put(\"<Stateful-mNumber>\", target.mNumber);",
+                        PUBLIC_STATIC_VOID_SAVE_STATE_I_TARGET_BUNDLE_STATE,
+                        IF_STATE_NULL,
+                        THROW_NEW_E_STATE_CANNOT_BE_NULL,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE,
+                        BUNDLE_WRAPPER_PUT_STATEFUL_M_TEXT_TARGET_M_TEXT,
+                        BUNDLE_WRAPPER_PUT_STATEFUL_M_NUMBER_TARGET_M_NUMBER,
                         "   }",
                         "",
                         "   @Weave(into = \"onRestoreInstanceState\", args = {\"android.os.Parcelable\"}, ",
                         "       statement = \"if ($1 instanceof android.os.Bundle) {android.os.Bundle bundle = (android.os.Bundle) $1;com.example.$T.restoreState(this, bundle);super.onRestoreInstanceState(bundle.getParcelable('PARENT_STATE'));} else {super.onRestoreInstanceState($1);}return;\")",
-                        "   public static void restoreState($I target, Bundle state) {",
-                        "       if (state == null) {",
-                        "           return;",
-                        "       }",
-                        "       BundleWrapper bundleWrapper = BundleWrapper.from(state);",
-                        "       target.mText = bundleWrapper.get(\"<Stateful-mText>\", target.mText);",
-                        "       target.mNumber = bundleWrapper.get(\"<Stateful-mNumber>\", target.mNumber);",
+                        PUBLIC_STATIC_VOID_RESTORE_STATE_I_TARGET_BUNDLE_STATE,
+                        IF_STATE_NULL,
+                        RETURN,
+                        CLOSING_BRACE,
+                        BUNDLE_WRAPPER_BUNDLE_WRAPPER_BUNDLE_WRAPPER_FROM_STATE,
+                        TARGET_M_TEXT_BUNDLE_WRAPPER_GET_STATEFUL_M_TEXT_TARGET_M_TEXT,
+                        TARGET_M_NUMBER_BUNDLE_WRAPPER_GET_STATEFUL_M_NUMBER_TARGET_M_NUMBER,
                         "   }",
                         "",
                         "}"

--- a/core-compiler/src/test/java/eu/f3rog/blade/compiler/util/File.java
+++ b/core-compiler/src/test/java/eu/f3rog/blade/compiler/util/File.java
@@ -35,14 +35,6 @@ public class File implements IImports, IBody {
     private static final CharSequence KEY_SIGN = "$";
     private static final String KEY_FORMAT = "\\" + KEY_SIGN + "%s";
 
-    public static IImports file(String pack, String name) {
-        return new File(pack, name);
-    }
-
-    public static IImports generatedFile(String pack, String name) {
-        return new File(pack, name, Generated.class);
-    }
-
     private final String mName;
     private final String mPackage;
     private LinkedHashSet<Object> mImportClasses;
@@ -64,6 +56,15 @@ public class File implements IImports, IBody {
         mMapping = new HashMap<>();
         mMapping.put(CLASS, mName);
     }
+
+    public static IImports file(String pack, String name) {
+        return new File(pack, name);
+    }
+
+    public static IImports generatedFile(String pack, String name) {
+        return new File(pack, name, Generated.class);
+    }
+
 
     @Override
     public IBody imports(Object... classes) {

--- a/core/src/main/java/eu/f3rog/blade/core/BundleWrapper.java
+++ b/core/src/main/java/eu/f3rog/blade/core/BundleWrapper.java
@@ -14,10 +14,6 @@ import java.io.Serializable;
  */
 public class BundleWrapper {
 
-    public static BundleWrapper from(Bundle bundle) {
-        return new BundleWrapper(bundle);
-    }
-
     private Bundle mBundle;
 
     public BundleWrapper(Bundle bundle) {
@@ -30,6 +26,10 @@ public class BundleWrapper {
 
     public Bundle getBundle() {
         return mBundle;
+    }
+
+    public static BundleWrapper from(Bundle bundle) {
+        return new BundleWrapper(bundle);
     }
 
     //region PUT ----------------------------

--- a/module/arg-compiler/src/main/java/eu/f3rog/blade/compiler/arg/ArgHelperModule.java
+++ b/module/arg-compiler/src/main/java/eu/f3rog/blade/compiler/arg/ArgHelperModule.java
@@ -39,11 +39,11 @@ public class ArgHelperModule extends BaseHelperModule {
 
     private static final String ARG_ID_FORMAT = "<Arg-%s>";
 
+    private final List<String> mArgs = new ArrayList<>();
+
     public static String getArgId(String arg) {
         return String.format(ARG_ID_FORMAT, arg);
     }
-
-    private final List<String> mArgs = new ArrayList<>();
 
     @Override
     public void checkClass(TypeElement e) throws ProcessorError {

--- a/module/extra-compiler/src/main/java/eu/f3rog/blade/compiler/extra/ExtraHelperModule.java
+++ b/module/extra-compiler/src/main/java/eu/f3rog/blade/compiler/extra/ExtraHelperModule.java
@@ -47,12 +47,12 @@ public class ExtraHelperModule extends BaseHelperModule {
 
     private static final String EXTRA_ID_FORMAT = "<Extra-%s>";
 
+    private List<String> mExtras = new ArrayList<>();
+    private Injected mInjected;
+
     public static String getExtraId(String extra) {
         return String.format(EXTRA_ID_FORMAT, extra);
     }
-
-    private List<String> mExtras = new ArrayList<>();
-    private Injected mInjected;
 
     @Override
     public void checkClass(TypeElement e) throws ProcessorError {

--- a/module/mvp-compiler/src/main/java/eu/f3rog/blade/compiler/mvp/PresenterHelperModule.java
+++ b/module/mvp-compiler/src/main/java/eu/f3rog/blade/compiler/mvp/PresenterHelperModule.java
@@ -45,6 +45,10 @@ import static eu.f3rog.blade.compiler.util.ProcessorUtils.isSubClassOf;
  */
 public class PresenterHelperModule extends BaseHelperModule {
 
+    public static final String TARGET = "target";
+    public static final String IF_N_N_NULL = "if ($N.$N != null)";
+    public static final String S_S_THIS = "%s.%s(this);";
+
     private enum ViewType {
         ACTIVITY, VIEW
     }
@@ -137,7 +141,7 @@ public class PresenterHelperModule extends BaseHelperModule {
 
     private void addSetPresenterMethod(HelperClassBuilder builder) {
         String tagObject = "tagObject";
-        String target = "target";
+        String target = TARGET;
 
         boolean returnsString = (mViewType == ViewType.VIEW);
 
@@ -160,7 +164,7 @@ public class PresenterHelperModule extends BaseHelperModule {
         for (int i = 0; i < mPresenters.size(); i++) {
             String fieldName = mPresenters.get(i);
 
-            method.beginControlFlow("if ($N.$N != null)", target, fieldName)
+            method.beginControlFlow(IF_N_N_NULL, target, fieldName)
                     .addStatement("$N.$N.unbind()", target, fieldName)
                     .endControlFlow();
             method.addStatement("$N.$N = null", target, fieldName);
@@ -229,7 +233,7 @@ public class PresenterHelperModule extends BaseHelperModule {
     }
 
     private void addBindPresenterMethod(HelperClassBuilder builder) {
-        String target = "target";
+        String target = TARGET;
 
         MethodSpec.Builder method = MethodSpec.methodBuilder(METHOD_NAME_BIND_PRESENTERS)
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
@@ -238,7 +242,7 @@ public class PresenterHelperModule extends BaseHelperModule {
         if (mViewType == ViewType.VIEW) {
             method.addAnnotation(
                     WeaveBuilder.weave().method("onAttachedToWindow")
-                            .withStatement("%s.%s(this);", fullName(builder.getClassName()), METHOD_NAME_BIND_PRESENTERS)
+                            .withStatement(S_S_THIS, fullName(builder.getClassName()), METHOD_NAME_BIND_PRESENTERS)
                             .withStatement(" this.%s = true;", FIELD_NAME_IS_ATTACHED)
                             .build()
             );
@@ -247,7 +251,7 @@ public class PresenterHelperModule extends BaseHelperModule {
         for (int i = 0; i < mPresenters.size(); i++) {
             String fieldName = mPresenters.get(i);
 
-            method.beginControlFlow("if ($N.$N != null)", target, fieldName)
+            method.beginControlFlow(IF_N_N_NULL, target, fieldName)
                     .addStatement("$N.$N.bind($N)", target, fieldName, target)
                     .endControlFlow();
         }
@@ -256,7 +260,7 @@ public class PresenterHelperModule extends BaseHelperModule {
     }
 
     private void addUnbindPresenterMethod(HelperClassBuilder builder) {
-        String target = "target";
+        String target = TARGET;
 
         MethodSpec.Builder method = MethodSpec.methodBuilder(METHOD_NAME_UNBIND_PRESENTERS)
                 .addAnnotation(
@@ -268,7 +272,7 @@ public class PresenterHelperModule extends BaseHelperModule {
         for (int i = 0; i < mPresenters.size(); i++) {
             String fieldName = mPresenters.get(i);
 
-            method.beginControlFlow("if ($N.$N != null)", target, fieldName)
+            method.beginControlFlow(IF_N_N_NULL, target, fieldName)
                     .addStatement("$N.$N.unbind()", target, fieldName)
                     .endControlFlow();
         }
@@ -280,12 +284,12 @@ public class PresenterHelperModule extends BaseHelperModule {
         switch (mViewType) {
             case VIEW:
                 return WeaveBuilder.weave().method("onDetachedFromWindow")
-                        .withStatement("%s.%s(this);", fullName(builder.getClassName()), METHOD_NAME_UNBIND_PRESENTERS)
+                        .withStatement(S_S_THIS, fullName(builder.getClassName()), METHOD_NAME_UNBIND_PRESENTERS)
                         .withStatement(" this.%s = false;", FIELD_NAME_IS_ATTACHED)
                         .build();
             case ACTIVITY:
                 return WeaveBuilder.weave().method("onDestroy")
-                        .withStatement("%s.%s(this);", fullName(builder.getClassName()), METHOD_NAME_UNBIND_PRESENTERS)
+                        .withStatement(S_S_THIS, fullName(builder.getClassName()), METHOD_NAME_UNBIND_PRESENTERS)
                         .build();
             default:
                 return null;

--- a/module/mvp/src/main/java/blade/mvp/PresenterManager.java
+++ b/module/mvp/src/main/java/blade/mvp/PresenterManager.java
@@ -18,6 +18,14 @@ import eu.f3rog.blade.mvp.MvpActivity;
  */
 public class PresenterManager {
 
+    private static PresenterManager sInstance;
+
+    private final Map<Object, ActivityPresenterManager> mActivityPresenters;
+
+    private PresenterManager() {
+        mActivityPresenters = new HashMap<>();
+    }
+
     /**
      * Used internally by Blade library.
      */
@@ -123,19 +131,11 @@ public class PresenterManager {
     }
 
 
-    private static PresenterManager sInstance;
-
     private static PresenterManager getInstance() {
         if (sInstance == null) {
             sInstance = new PresenterManager();
         }
         return sInstance;
-    }
-
-    private final Map<Object, ActivityPresenterManager> mActivityPresenters;
-
-    private PresenterManager() {
-        mActivityPresenters = new HashMap<>();
     }
 
     private ActivityPresenterManager getActivityPresenters(Object activityId) {

--- a/plugin/src/main/java/eu/f3rog/afterburner/InsertableMethodBuilder.java
+++ b/plugin/src/main/java/eu/f3rog/afterburner/InsertableMethodBuilder.java
@@ -51,15 +51,6 @@ public class InsertableMethodBuilder {
         return new StateTargetClassSet();
     }
 
-    private void doInsertBodyInFullMethod() {
-        if (fullMethod != null) {
-            if (!fullMethod.contains(InsertableMethod.BODY_TAG)) {
-                log.info("Full method doesn't contain body tag (InsertableMethod.BODY_TAG=" + InsertableMethod.BODY_TAG + ")");
-            }
-            fullMethod = fullMethod.replace(InsertableMethod.BODY_TAG, body);
-        }
-    }
-
     protected void checkFields() throws AfterBurnerImpossibleException {
         if (classToInsertInto == null || targetMethod == null
                 || body == null || fullMethod == null) {
@@ -74,6 +65,11 @@ public class InsertableMethodBuilder {
 
 
     public class StateTargetClassSet {
+
+        public static final String CLASS_S_DOESN_T_CONTAIN_ANY_METHOD_NAMED_S = "Class %s doesn't contain any method named %s";
+        public static final String OPENING_BRACE_NEW_LINE_CHARACTER = " { \n";
+        public static final String CREATING_OVERRIDE = "Creating override ";
+
         public StateTargetMethodSet inMethodIfExists(String targetMethod, CtClass... targetMethodParams) {
             InsertableMethodBuilder.this.targetMethod = targetMethod;
             InsertableMethodBuilder.this.targetMethodParams = targetMethodParams;
@@ -86,16 +82,16 @@ public class InsertableMethodBuilder {
             // set no insertion method ! (it will be insert at the beginning)
             CtMethod overridenMethod = findTargetMethod(targetMethod, targetMethodParams);
             if (overridenMethod == null) {
-                throw new NotFoundException(String.format("Class %s doesn't contain any method named %s", classToInsertInto.getName(), targetMethod));
+                throw new NotFoundException(String.format(CLASS_S_DOESN_T_CONTAIN_ANY_METHOD_NAMED_S, classToInsertInto.getName(), targetMethod));
             }
             fullMethod = signatureExtractor
                     .createJavaSignature(overridenMethod)
-                    + " { \n"
+                    + OPENING_BRACE_NEW_LINE_CHARACTER
                     + InsertableMethod.BODY_TAG
                     + "\n"
                     + ((!overridenMethod.getReturnType().toString().equals("void")) ? "return " : "")
                     + signatureExtractor.invokeSuper(overridenMethod) + "}\n";
-            log.info("Creating override " + fullMethod);
+            log.info(CREATING_OVERRIDE + fullMethod);
             return new StateInsertionPointAndFullMethodSet();
         }
 
@@ -105,15 +101,15 @@ public class InsertableMethodBuilder {
             InsertableMethodBuilder.this.insertionBeforeMethod = targetMethod;
             CtMethod overridenMethod = findTargetMethod(targetMethod, targetMethodParams);
             if (overridenMethod == null) {
-                throw new NotFoundException(String.format("Class %s doesn't contain any method named %s", classToInsertInto.getName(), targetMethod));
+                throw new NotFoundException(String.format(CLASS_S_DOESN_T_CONTAIN_ANY_METHOD_NAMED_S, classToInsertInto.getName(), targetMethod));
             }
             fullMethod = signatureExtractor
                     .createJavaSignature(overridenMethod)
-                    + " { \n"
+                    + OPENING_BRACE_NEW_LINE_CHARACTER
                     + InsertableMethod.BODY_TAG
                     + "\n"
                     + signatureExtractor.invokeSuper(overridenMethod) + "}\n";
-            log.info("Creating override " + fullMethod);
+            log.info(CREATING_OVERRIDE + fullMethod);
             return new StateInsertionPointAndFullMethodSet();
         }
 
@@ -122,15 +118,15 @@ public class InsertableMethodBuilder {
             InsertableMethodBuilder.this.insertionAfterMethod = targetMethod;
             CtMethod overridenMethod = findTargetMethod(targetMethod, targetMethodParams);
             if (overridenMethod == null) {
-                throw new NotFoundException(String.format("Class %s doesn't contain any method named %s", classToInsertInto.getName(), targetMethod));
+                throw new NotFoundException(String.format(CLASS_S_DOESN_T_CONTAIN_ANY_METHOD_NAMED_S, classToInsertInto.getName(), targetMethod));
             }
             fullMethod = signatureExtractor
                     .createJavaSignature(overridenMethod)
-                    + " { \n"
+                    + OPENING_BRACE_NEW_LINE_CHARACTER
                     + signatureExtractor.invokeSuper(overridenMethod)
                     + "\n"
                     + InsertableMethod.BODY_TAG + "}\n";
-            log.info("Creating override " + fullMethod);
+            log.info(CREATING_OVERRIDE + fullMethod);
             return new StateInsertionPointAndFullMethodSet();
         }
 
@@ -207,6 +203,15 @@ public class InsertableMethodBuilder {
     }
 
     public class StateComplete {
+
+        private void doInsertBodyInFullMethod() {
+            if (fullMethod != null) {
+                if (!fullMethod.contains(InsertableMethod.BODY_TAG)) {
+                    log.info("Full method doesn't contain body tag (InsertableMethod.BODY_TAG=" + InsertableMethod.BODY_TAG + ")");
+                }
+                fullMethod = fullMethod.replace(InsertableMethod.BODY_TAG, body);
+            }
+        }
 
         public InsertableMethod createInsertableMethod() throws AfterBurnerImpossibleException {
             checkFields();

--- a/plugin/src/main/java/eu/f3rog/afterburner/Utils.java
+++ b/plugin/src/main/java/eu/f3rog/afterburner/Utils.java
@@ -12,6 +12,8 @@ import javassist.NotFoundException;
  */
 public class Utils {
 
+    private Utils() {}
+
     public static CtMethod findTargetMethod(CtClass ctClass, String targetMethod, CtClass... targetMethodParams) {
         CtMethod overriddenMethod = null;
         try {

--- a/plugin/src/main/java/eu/f3rog/blade/weaving/util/AWeaver.java
+++ b/plugin/src/main/java/eu/f3rog/blade/weaving/util/AWeaver.java
@@ -33,7 +33,7 @@ public abstract class AWeaver implements IWeaver {
 
     protected void log(String msg, Object... args) {
         if (mDebug) {
-            String format = String.format("@ %s : %s\n", getClass().getSimpleName(), msg);
+            String format = String.format("@ %s : %s%n", getClass().getSimpleName(), msg);
             System.out.printf(format, args);
         }
     }

--- a/plugin/src/main/java/eu/f3rog/blade/weaving/util/WeavingUtil.java
+++ b/plugin/src/main/java/eu/f3rog/blade/weaving/util/WeavingUtil.java
@@ -14,11 +14,12 @@ import javassist.bytecode.AnnotationsAttribute;
  */
 public class WeavingUtil {
 
+    private WeavingUtil() {}
+
     public static boolean isSubclassOf(CtClass clazz, String superClassName) throws NotFoundException {
         CtClass superClass = clazz;
 
         do {
-            //System.out.printf("isSubclassOf %s : %s\n", superClassName, superClass.getName());
             if (superClass.getName().equals(superClassName)) return true;
             superClass = superClass.getSuperclass();
         } while (superClass != null);

--- a/sample/src/main/java/eu/f3rog/blade/sample/arg/SampleDialogFragment.java
+++ b/sample/src/main/java/eu/f3rog/blade/sample/arg/SampleDialogFragment.java
@@ -21,16 +21,6 @@ public class SampleDialogFragment extends DialogFragment {
     @Arg
     String mMessage;
 
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-    }
-
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-    }
-
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {

--- a/sample/src/main/java/eu/f3rog/blade/sample/mvp/di/component/Component.java
+++ b/sample/src/main/java/eu/f3rog/blade/sample/mvp/di/component/Component.java
@@ -12,6 +12,8 @@ public class Component {
 
     private static AppComponent sAppComponent = null;
 
+    private Component() {}
+
     public static AppComponent forApp() {
         if (sAppComponent == null) {
             sAppComponent = DaggerAppComponent


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1118 - Utility classes should not have public constructors.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1185 - Overriding methods should do more than simply call the same method in the super class.
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:S3398 -  "private" methods called only by inner classes should be moved to those classes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1185
https://dev.eclipse.org/sonar/rules/show/squid:S2275
Please let me know if you have any questions.
George Kankava