### PR TITLE
@WeaveInto

### DIFF
--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/annotation/WeaveIntoBuilder.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/annotation/WeaveIntoBuilder.java
@@ -1,0 +1,15 @@
+package eu.f3rog.blade.compiler.builder.annotation;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+
+import eu.f3rog.blade.compiler.util.ProcessorUtils;
+import eu.f3rog.blade.core.WeaveInto;
+
+public class WeaveIntoBuilder {
+    public static AnnotationSpec buildFor(ClassName className) {
+        return AnnotationSpec.builder(WeaveInto.class)
+                .addMember("target", "\"" + ProcessorUtils.fullName(className) + "\"")
+                .build();
+    }
+}

--- a/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/helper/HelperClassBuilder.java
+++ b/core-compiler/src/main/java/eu/f3rog/blade/compiler/builder/helper/HelperClassBuilder.java
@@ -13,6 +13,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 
 import eu.f3rog.blade.compiler.builder.BaseClassBuilder;
+import eu.f3rog.blade.compiler.builder.annotation.WeaveIntoBuilder;
 import eu.f3rog.blade.compiler.name.GCN;
 import eu.f3rog.blade.compiler.util.ClassComparator;
 import eu.f3rog.blade.compiler.util.ProcessorError;
@@ -40,6 +41,9 @@ public class HelperClassBuilder
         super.start();
 
         getBuilder().addModifiers(Modifier.ABSTRACT);
+        if (getArgClassName() != null) {
+            getBuilder().addAnnotation(WeaveIntoBuilder.buildFor(getArgClassName()));
+        }
     }
 
     @Override

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/arg/ArgHelperSpecification.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/arg/ArgHelperSpecification.groovy
@@ -11,6 +11,7 @@ import eu.f3rog.blade.compiler.util.JavaFile
 import eu.f3rog.blade.core.BundleWrapper
 import blade.Bundler
 import eu.f3rog.blade.core.Weave
+import eu.f3rog.blade.core.WeaveInto
 import spock.lang.Unroll
 
 import javax.tools.JavaFileObject
@@ -106,6 +107,9 @@ public final class ArgHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -125,7 +129,7 @@ public final class ArgHelperSpecification
                 """,
                 [
                         I: input,
-                        _: [BundleWrapper.class, Weave.class]
+                        _: [BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -172,6 +176,9 @@ public final class ArgHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -193,7 +200,7 @@ public final class ArgHelperSpecification
                 [
                         I : input,
                         CB: customBundler,
-                        _ : [BundleWrapper.class, Weave.class]
+                        _ : [BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -223,6 +230,9 @@ public final class ArgHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -242,7 +252,7 @@ public final class ArgHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Weave.class]
+                        _ : [BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -272,6 +282,9 @@ public final class ArgHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -291,7 +304,7 @@ public final class ArgHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Weave.class, Serializable.class]
+                        _ : [BundleWrapper.class, Weave.class, Serializable.class, WeaveInto.class]
                 ]
         )
 
@@ -324,6 +337,9 @@ public final class ArgHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyFragment"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -343,7 +359,7 @@ public final class ArgHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Weave.class]
+                        _ : [BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -382,6 +398,9 @@ public final class ArgHelperSpecification
         expect:
         final JavaFileObject expected1 = JavaFile.newGeneratedFile("com.example", "Wrapper_MyFragment1_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyFragment1"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -401,11 +420,14 @@ public final class ArgHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Weave.class]
+                        _ : [BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
         final JavaFileObject expected2 = JavaFile.newGeneratedFile("com.example", "Wrapper_MyFragment2_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyFragment2"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -425,7 +447,7 @@ public final class ArgHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Weave.class]
+                        _ : [BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/combination/CombinedSpecification.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/combination/CombinedSpecification.groovy
@@ -12,6 +12,7 @@ import eu.f3rog.blade.compiler.BladeProcessor
 import eu.f3rog.blade.compiler.util.JavaFile
 import eu.f3rog.blade.core.BundleWrapper
 import eu.f3rog.blade.core.Weave
+import eu.f3rog.blade.core.WeaveInto
 import spock.lang.Unroll
 
 import javax.tools.JavaFileObject
@@ -39,6 +40,9 @@ public final class CombinedSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -87,7 +91,8 @@ public final class CombinedSpecification
                         _ : [
                                 Bundle.class,
                                 BundleWrapper.class,
-                                Weave.class
+                                Weave.class,
+                                WeaveInto.class
                         ]
                 ]
         )
@@ -124,6 +129,9 @@ public final class CombinedSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -174,7 +182,8 @@ public final class CombinedSpecification
                                 Bundle.class,
                                 BundleWrapper.class,
                                 Intent.class,
-                                Weave.class
+                                Weave.class,
+                                WeaveInto.class
                         ]
                 ]
         )

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/extra/ExtraHelperSpecification.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/extra/ExtraHelperSpecification.groovy
@@ -15,6 +15,7 @@ import eu.f3rog.blade.compiler.util.JavaFile
 import eu.f3rog.blade.core.BundleWrapper
 import blade.Bundler
 import eu.f3rog.blade.core.Weave
+import eu.f3rog.blade.core.WeaveInto
 import spock.lang.Unroll
 
 import javax.tools.JavaFileObject
@@ -117,6 +118,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -137,7 +141,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I: input,
-                        _: [BundleWrapper.class, Intent.class, Weave.class]
+                        _: [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -184,6 +188,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -206,7 +213,7 @@ public final class ExtraHelperSpecification
                 [
                         I : input,
                         CB: customBundler,
-                        _ : [BundleWrapper.class, Intent.class, Weave.class]
+                        _ : [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -240,6 +247,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyService_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -259,7 +269,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I: input,
-                        _: [BundleWrapper.class, Intent.class, Weave.class]
+                        _: [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -297,6 +307,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyIntentService_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -316,7 +329,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I: input,
-                        _: [BundleWrapper.class, Intent.class, Weave.class]
+                        _: [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -346,6 +359,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -366,7 +382,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Intent.class, Weave.class]
+                        _ : [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -396,6 +412,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -416,7 +435,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Intent.class, Serializable.class, Weave.class]
+                        _ : [BundleWrapper.class, Intent.class, Serializable.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -449,6 +468,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyActivity"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -469,7 +491,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Intent.class, Weave.class]
+                        _ : [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -508,6 +530,9 @@ public final class ExtraHelperSpecification
         expect:
         final JavaFileObject expected1 = JavaFile.newGeneratedFile("com.example", "Wrapper_MyActivity1_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyActivity1"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -528,11 +553,14 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Intent.class, Weave.class]
+                        _ : [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
         final JavaFileObject expected2 = JavaFile.newGeneratedFile("com.example", "Wrapper_MyActivity2_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyActivity2"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -553,7 +581,7 @@ public final class ExtraHelperSpecification
                 """,
                 [
                         I : input,
-                        _ : [BundleWrapper.class, Intent.class, Weave.class]
+                        _ : [BundleWrapper.class, Intent.class, Weave.class, WeaveInto.class]
                 ]
         )
 

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/mvp/MvpHelperSpecification.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/mvp/MvpHelperSpecification.groovy
@@ -11,6 +11,8 @@ import blade.mvp.IView
 import eu.f3rog.blade.compiler.BaseSpecification
 import eu.f3rog.blade.compiler.BladeProcessor
 import eu.f3rog.blade.compiler.util.JavaFile
+import eu.f3rog.blade.core.Weave
+import eu.f3rog.blade.core.WeaveInto
 import eu.f3rog.blade.mvp.WeavedMvpActivity
 import eu.f3rog.blade.mvp.WeavedMvpFragment
 import eu.f3rog.blade.mvp.WeavedMvpView
@@ -338,11 +340,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#A"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpActivity.class
+                        A: activity,
+                        M: WeavedMvpActivity.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -392,11 +399,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#A"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpActivity.class
+                        A: activity,
+                        M: WeavedMvpActivity.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -458,11 +470,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#A"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpActivity.class
+                        A: activity,
+                        M: WeavedMvpActivity.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -539,11 +556,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#F"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpFragment.class
+                        F: fragment,
+                        M: WeavedMvpFragment.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -605,11 +627,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#F"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpFragment.class
+                        F: fragment,
+                        M: WeavedMvpFragment.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -694,11 +721,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#V"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpView.class
+                        V: view,
+                        M: WeavedMvpView.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -764,11 +796,16 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#V"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpView.class
+                        V: view,
+                        M: WeavedMvpView.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -819,11 +856,15 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.Wrapper.MyActivity"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpActivity.class
+                        M: WeavedMvpActivity.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -874,11 +915,15 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.Wrapper.MyFragment"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpFragment.class
+                        M: WeavedMvpFragment.class,
+                        _: [WeaveInto.class]
                 ]
         )
 
@@ -933,11 +978,15 @@ public final class MvpHelperSpecification
 
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.Wrapper.MyView"
+                )
                 abstract class #T implements #M {
                 }
                 """,
                 [
-                        M: WeavedMvpView.class
+                        M: WeavedMvpView.class,
+                        _: [WeaveInto.class]
                 ]
         )
 

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/parcel/ParcelHelperSpecification.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/parcel/ParcelHelperSpecification.groovy
@@ -8,6 +8,7 @@ import eu.f3rog.blade.compiler.BaseSpecification
 import eu.f3rog.blade.compiler.BladeProcessor
 import eu.f3rog.blade.compiler.util.JavaFile
 import eu.f3rog.blade.core.Weave
+import eu.f3rog.blade.core.WeaveInto
 
 import javax.tools.JavaFileObject
 
@@ -213,6 +214,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -306,7 +310,8 @@ public final class ParcelHelperSpecification
                                 Parcelable.class,
                                 Object.class,
                                 Override.class,
-                                Weave.class
+                                Weave.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -365,6 +370,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -432,7 +440,8 @@ public final class ParcelHelperSpecification
                                 HashSet.class,
                                 List.class,
                                 Map.class,
-                                Set.class
+                                Set.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -476,6 +485,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -519,7 +531,8 @@ public final class ParcelHelperSpecification
                                 android.os.Parcel.class,
                                 Parcelable.class,
                                 Weave.class,
-                                Override.class
+                                Override.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -653,6 +666,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -698,7 +714,8 @@ public final class ParcelHelperSpecification
                                 android.os.Parcel.class,
                                 Parcelable.class,
                                 Weave.class,
-                                Override.class
+                                Override.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -744,6 +761,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -787,7 +807,8 @@ public final class ParcelHelperSpecification
                                 android.os.Parcel.class,
                                 Parcelable.class,
                                 Weave.class,
-                                Override.class
+                                Override.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -841,6 +862,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -884,7 +908,8 @@ public final class ParcelHelperSpecification
                                 android.os.Parcel.class,
                                 Parcelable.class,
                                 Weave.class,
-                                Override.class
+                                Override.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -939,6 +964,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -989,6 +1017,7 @@ public final class ParcelHelperSpecification
                                 Parcelable.class,
                                 String.class,
                                 Weave.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -1031,6 +1060,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -1075,6 +1107,7 @@ public final class ParcelHelperSpecification
                                 android.os.Parcel.class,
                                 Parcelable.class,
                                 Weave.class,
+                                WeaveInto.class,
                         ]
                 ]
         )
@@ -1117,6 +1150,9 @@ public final class ParcelHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -1161,7 +1197,8 @@ public final class ParcelHelperSpecification
                                 android.os.Parcel.class,
                                 Parcelable.class,
                                 String.class,
-                                Weave.class
+                                Weave.class,
+                                WeaveInto.class,
                         ]
                 ]
         )

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/state/StateHelperSpecification.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/state/StateHelperSpecification.groovy
@@ -17,6 +17,7 @@ import eu.f3rog.blade.compiler.util.JavaFile
 import eu.f3rog.blade.core.BundleWrapper
 import blade.Bundler
 import eu.f3rog.blade.core.Weave
+import eu.f3rog.blade.core.WeaveInto
 import spock.lang.Unroll
 
 import javax.tools.JavaFileObject
@@ -95,6 +96,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     public static void saveState(#I target, Bundle state) {
                         if (state == null) {
@@ -118,7 +122,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class]
+                        _: [Bundle.class, BundleWrapper.class, WeaveInto.class]
                 ]
         )
 
@@ -164,6 +168,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     public static void saveState(#I target, Bundle state) {
                         if (state == null) {
@@ -192,7 +199,7 @@ public final class StateHelperSpecification
                         CB: customBundler,
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class]
+                        _ : [Bundle.class, BundleWrapper.class, WeaveInto.class]
                 ]
         )
 
@@ -222,6 +229,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyActivity_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0_onSaveInstanceState",
@@ -255,7 +265,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -285,6 +295,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyFragment_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0_onSaveInstanceState",
@@ -318,7 +331,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -349,6 +362,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyPresenter_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0_onSaveState",
@@ -382,7 +398,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -416,6 +432,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0^onSaveInstanceState",
@@ -448,7 +467,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -487,6 +506,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0^onSaveInstanceState/onSaveInstanceState_BladeState",
@@ -519,7 +541,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -557,6 +579,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0^onSaveInstanceState",
@@ -589,7 +614,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -632,6 +657,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
                     @Weave(
                         into = "0^onSaveInstanceState/onSaveInstanceState_BladeState",
@@ -664,7 +692,7 @@ public final class StateHelperSpecification
                 [
                         I: input,
                         E: IllegalArgumentException.class,
-                        _: [Bundle.class, BundleWrapper.class, Weave.class]
+                        _: [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -694,6 +722,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     public static <T> void saveState(#I<T> target, Bundle state) {
@@ -718,7 +749,7 @@ public final class StateHelperSpecification
                 [
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class]
+                        _ : [Bundle.class, BundleWrapper.class, WeaveInto.class]
                 ]
         )
 
@@ -748,6 +779,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I"
+                )
                 abstract class #T {
 
                     public static <T extends Serializable> void saveState(#I<T> target, Bundle state) {
@@ -772,7 +806,7 @@ public final class StateHelperSpecification
                 [
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class, Serializable.class]
+                        _ : [Bundle.class, BundleWrapper.class, Serializable.class, WeaveInto.class]
                 ]
         )
 
@@ -809,6 +843,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyView_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyView"
+                )
                 abstract class #T {
 
                     @Weave(
@@ -842,7 +879,7 @@ public final class StateHelperSpecification
                 [
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class, Weave.class]
+                        _ : [Bundle.class, BundleWrapper.class, Weave.class, WeaveInto.class]
                 ]
         )
 
@@ -875,6 +912,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected = JavaFile.newGeneratedFile("com.example", "Wrapper_MyClass_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyClass"
+                )
                 abstract class #T {
 
                     public static void saveState(#I.MyClass target, Bundle state) {
@@ -899,7 +939,7 @@ public final class StateHelperSpecification
                 [
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class]
+                        _ : [Bundle.class, BundleWrapper.class, WeaveInto.class]
                 ]
         )
 
@@ -938,6 +978,9 @@ public final class StateHelperSpecification
         expect:
         final JavaFileObject expected1 = JavaFile.newGeneratedFile("com.example", "Wrapper_MyClass1_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyClass1"
+                )
                 abstract class #T {
 
                     public static void saveState(#I.MyClass1 target, Bundle state) {
@@ -962,11 +1005,14 @@ public final class StateHelperSpecification
                 [
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class]
+                        _ : [Bundle.class, BundleWrapper.class, WeaveInto.class]
                 ]
         )
         final JavaFileObject expected2 = JavaFile.newGeneratedFile("com.example", "Wrapper_MyClass2_Helper",
                 """
+                @WeaveInto(
+                    target = "com.example.#I.MyClass2"
+                )
                 abstract class #T {
 
                     public static void saveState(#I.MyClass2 target, Bundle state) {
@@ -991,7 +1037,7 @@ public final class StateHelperSpecification
                 [
                         I : input,
                         E : IllegalArgumentException.class,
-                        _ : [Bundle.class, BundleWrapper.class]
+                        _ : [Bundle.class, BundleWrapper.class, WeaveInto.class]
                 ]
         )
 

--- a/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/util/JavaFile.groovy
+++ b/core-compiler/src/test/groovy/eu/f3rog/blade/compiler/util/JavaFile.groovy
@@ -106,6 +106,7 @@ public final class JavaFile {
         } else if (value instanceof JavaFileObject) {
             className = ((JavaFileObject) value).getName()
                     .replace(java.io.File.separator, ".")
+                    .replace("/", ".") // NOTE: Windows seems to return / for separators from getName()
                     .replace(".java", "");
         }
 

--- a/core/src/main/java/eu/f3rog/blade/core/WeaveInto.java
+++ b/core/src/main/java/eu/f3rog/blade/core/WeaveInto.java
@@ -1,0 +1,12 @@
+package eu.f3rog.blade.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WeaveInto {
+    String target();
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1536M
 
 LIB_GROUP_ID = eu.f3rog.blade
 ARTIFACT_ID = none
-LIB_VERSION = 2.6.2
+LIB_VERSION = 2.6.2-weave-into
 
 LIB_VERSION_DESC = Android Library for Boilerplate Destruction
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1536M
 
 LIB_GROUP_ID = eu.f3rog.blade
 ARTIFACT_ID = none
-LIB_VERSION = 2.6.2-weave-into
+LIB_VERSION = 2.6.2-weave-into-a
 
 LIB_VERSION_DESC = Android Library for Boilerplate Destruction
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1536M
 
 LIB_GROUP_ID = eu.f3rog.blade
 ARTIFACT_ID = none
-LIB_VERSION = 2.6.2-weave-into-a
+LIB_VERSION = 2.6.2-weave-into-b
 
 LIB_VERSION_DESC = Android Library for Boilerplate Destruction
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1536M
 
 LIB_GROUP_ID = eu.f3rog.blade
 ARTIFACT_ID = none
-LIB_VERSION = 2.6.2-weave-into-b
+LIB_VERSION = 2.6.2-weave-into-c
 
 LIB_VERSION_DESC = Android Library for Boilerplate Destruction
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1536M
 
 LIB_GROUP_ID = eu.f3rog.blade
 ARTIFACT_ID = none
-LIB_VERSION = 2.6.2-weave-into-c
+LIB_VERSION = 2.6.2-weave-into-d
 
 LIB_VERSION_DESC = Android Library for Boilerplate Destruction
 

--- a/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
+++ b/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
@@ -32,7 +32,7 @@ public final class BladePlugin
     public static String ERROR_CONFIG_FILE_IS_MISSING = "Blade configuration file is missing! (more info here: https://github.com/FrantisekGazo/Blade/wiki#1-create-configuration-file)"
 
     public static String LIB_GROUP_ID = "eu.f3rog.blade"
-    public static String LIB_VERSION = "2.6.2-weave-into"
+    public static String LIB_VERSION = "2.6.2-weave-into-a"
     public static String LIB_CONFIG_FILE_NAME = "blade"
     public static String[] LIB_MODULES = ["arg", "extra", "mvp", "parcel", "state"]
 

--- a/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
+++ b/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
@@ -32,7 +32,7 @@ public final class BladePlugin
     public static String ERROR_CONFIG_FILE_IS_MISSING = "Blade configuration file is missing! (more info here: https://github.com/FrantisekGazo/Blade/wiki#1-create-configuration-file)"
 
     public static String LIB_GROUP_ID = "eu.f3rog.blade"
-    public static String LIB_VERSION = "2.6.2-weave-into-c"
+    public static String LIB_VERSION = "2.6.2-weave-into-d"
     public static String LIB_CONFIG_FILE_NAME = "blade"
     public static String[] LIB_MODULES = ["arg", "extra", "mvp", "parcel", "state"]
 

--- a/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
+++ b/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
@@ -32,7 +32,7 @@ public final class BladePlugin
     public static String ERROR_CONFIG_FILE_IS_MISSING = "Blade configuration file is missing! (more info here: https://github.com/FrantisekGazo/Blade/wiki#1-create-configuration-file)"
 
     public static String LIB_GROUP_ID = "eu.f3rog.blade"
-    public static String LIB_VERSION = "2.6.2-weave-into-b"
+    public static String LIB_VERSION = "2.6.2-weave-into-c"
     public static String LIB_CONFIG_FILE_NAME = "blade"
     public static String[] LIB_MODULES = ["arg", "extra", "mvp", "parcel", "state"]
 
@@ -54,6 +54,7 @@ public final class BladePlugin
 
         prepareConfig(project)
 
+        project.repositories.add(project.getRepositories().mavenLocal())
         project.repositories.add(project.getRepositories().jcenter())
         def apList = determineAnnotationProcessorPlugin(project)
         // core

--- a/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
+++ b/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
@@ -32,7 +32,7 @@ public final class BladePlugin
     public static String ERROR_CONFIG_FILE_IS_MISSING = "Blade configuration file is missing! (more info here: https://github.com/FrantisekGazo/Blade/wiki#1-create-configuration-file)"
 
     public static String LIB_GROUP_ID = "eu.f3rog.blade"
-    public static String LIB_VERSION = "2.6.2"
+    public static String LIB_VERSION = "2.6.2-weave-into"
     public static String LIB_CONFIG_FILE_NAME = "blade"
     public static String[] LIB_MODULES = ["arg", "extra", "mvp", "parcel", "state"]
 

--- a/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
+++ b/plugin/src/main/groovy/eu/f3rog/blade/plugin/BladePlugin.groovy
@@ -32,7 +32,7 @@ public final class BladePlugin
     public static String ERROR_CONFIG_FILE_IS_MISSING = "Blade configuration file is missing! (more info here: https://github.com/FrantisekGazo/Blade/wiki#1-create-configuration-file)"
 
     public static String LIB_GROUP_ID = "eu.f3rog.blade"
-    public static String LIB_VERSION = "2.6.2-weave-into-a"
+    public static String LIB_VERSION = "2.6.2-weave-into-b"
     public static String LIB_CONFIG_FILE_NAME = "blade"
     public static String[] LIB_MODULES = ["arg", "extra", "mvp", "parcel", "state"]
 

--- a/plugin/src/main/java/eu/f3rog/blade/weaving/BladeWeaver.java
+++ b/plugin/src/main/java/eu/f3rog/blade/weaving/BladeWeaver.java
@@ -36,16 +36,7 @@ public final class BladeWeaver
     public void weave(ClassPool classPool, List<CtClass> classes) {
         final List<Tuple2<CtClass, CtClass>> processingList = new ArrayList<>();
         for (CtClass cls : classes) {
-            String className = cls.getName();
-            if (className.endsWith("_Helper")) {
-                CtClass intoClass;
-                try {
-                    intoClass = classPool.get(className.replace("_Helper", ""));
-                } catch (NotFoundException e) {
-                    continue;
-                }
-                processingList.add(new Tuple2<>(cls, intoClass));
-            } else if (cls.hasAnnotation(WeaveInto.class)) {
+            if (cls.hasAnnotation(WeaveInto.class)) {
                 CtClass intoClass;
                 try {
                     intoClass = classPool.get(getWeaveClassTarget(cls));

--- a/plugin/src/main/java/eu/f3rog/blade/weaving/BladeWeaver.java
+++ b/plugin/src/main/java/eu/f3rog/blade/weaving/BladeWeaver.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import eu.f3rog.blade.compiler.builder.annotation.WeaveParser;
 import eu.f3rog.blade.core.Weave;
+import eu.f3rog.blade.core.WeaveInto;
 import eu.f3rog.blade.core.Weaves;
 import eu.f3rog.blade.weaving.interfaces.Interfaces;
 import eu.f3rog.blade.weaving.util.AWeaver;
@@ -36,6 +37,15 @@ public final class BladeWeaver
                 CtClass intoClass;
                 try {
                     intoClass = classPool.get(className.replace("_Helper", ""));
+                } catch (NotFoundException e) {
+                    continue;
+                }
+
+                weave(cls, intoClass);
+            } else if (cls.hasAnnotation(WeaveInto.class)) {
+                CtClass intoClass;
+                try {
+                    intoClass = classPool.get(getWeaveClassTarget(cls));
                 } catch (NotFoundException e) {
                     continue;
                 }
@@ -293,5 +303,15 @@ public final class BladeWeaver
         } else {
             return Collections.emptyList();
         }
+    }
+
+    private String getWeaveClassTarget(CtClass weaveClass) {
+        AnnotationsAttribute annotations = getAnnotations(weaveClass);
+
+        Annotation a = annotations.getAnnotation(WeaveInto.class.getName());
+        if (a != null) {
+            return a.getMemberValue("target").toString().replaceAll("\"", "");
+        }
+        return "";
     }
 }

--- a/plugin/src/main/java/eu/f3rog/blade/weaving/interfaces/WeavedMvpUiIW.java
+++ b/plugin/src/main/java/eu/f3rog/blade/weaving/interfaces/WeavedMvpUiIW.java
@@ -130,6 +130,9 @@ abstract class WeavedMvpUiIW
             CtClass presenterInterface = classPool.get("blade.mvp.IPresenter");
 
             for (CtField declaredField : declaredFields) {
+                if (!declaredField.visibleFrom(targetClass)) {
+                    continue;
+                }
                 if (declaredField.hasAnnotation(Inject.class) && declaredField.getType().subtypeOf(presenterInterface)) {
                     presenterFieldNames.add(declaredField.getName());
                 }

--- a/plugin/src/main/java/eu/f3rog/blade/weaving/interfaces/WeavedMvpUiIW.java
+++ b/plugin/src/main/java/eu/f3rog/blade/weaving/interfaces/WeavedMvpUiIW.java
@@ -123,14 +123,18 @@ abstract class WeavedMvpUiIW
     private List<String> getPresenterFieldNames(CtClass targetClass) throws NotFoundException {
         List<String> presenterFieldNames = new ArrayList<>();
 
-        ClassPool classPool = targetClass.getClassPool();
-        CtField[] declaredFields = targetClass.getDeclaredFields();
-        CtClass presenterInterface = classPool.get("blade.mvp.IPresenter");
+        CtClass ctClass = targetClass;
+        while (ctClass != null) {
+            ClassPool classPool = ctClass.getClassPool();
+            CtField[] declaredFields = ctClass.getDeclaredFields();
+            CtClass presenterInterface = classPool.get("blade.mvp.IPresenter");
 
-        for (CtField declaredField : declaredFields) {
-            if (declaredField.hasAnnotation(Inject.class) && declaredField.getType().subtypeOf(presenterInterface)) {
-                presenterFieldNames.add(declaredField.getName());
+            for (CtField declaredField : declaredFields) {
+                if (declaredField.hasAnnotation(Inject.class) && declaredField.getType().subtypeOf(presenterInterface)) {
+                    presenterFieldNames.add(declaredField.getName());
+                }
             }
+            ctClass = ctClass.getSuperclass();
         }
 
         return presenterFieldNames;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'eu.f3rog.blade:plugin:2.6.2-weave-into-b'
+        classpath 'eu.f3rog.blade:plugin:2.6.2-weave-into-c'
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
 
         classpath 'com.android.tools.build:gradle:2.2.2'
-        classpath 'eu.f3rog.blade:plugin:2.6.2'
+        classpath 'eu.f3rog.blade:plugin:2.6.2-weave-into-b'
     }
 }
 


### PR DESCRIPTION
**Functional Changes:**
Added `@WeaveInto` annotation to generify `BladeWeaver`.
Instead of it looking specifically for `[ClassName]_Helper` classes, now it will look for `@WeaveInto` annotations and weave them instead.
`@WeaveInto` has a target field which is the `intoClass` that `BladeWeaver` will weave the class into.
This allows for multiple classes to be 'woven' into the same class.
`Blade` modules have been adjusted to accommodate the change and their tests updated also.
The `HelperClassBuilder` now adds this annotation so works as it did before.

**Resolved Issue(s):**
There was one issue which I noticed while developing my side library that uses `BladeWeaver` where the ordering of the weaving mattered due to the hierarchy of the classes. (Only on older devices, was noticed on Android versions 5.1.1 and 6.0)
To resolve this issue the `BladeWeaver` orders the weaved classes by their `intoClass` superclass count so that when super calls are generated they are always calling the correct function.

There was another issue I noticed while running the tests on Windows where the `getName` call on the `JavaFileObject` was returning incorrect separators. I have added a line so that tests will run successfully on Windows.  (JavaFile.groovy - `.replace("/", ".")`)